### PR TITLE
feat: support TRUNCATE replication events

### DIFF
--- a/internal/iceberg/writer.go
+++ b/internal/iceberg/writer.go
@@ -82,6 +82,13 @@ func (w *Writer) Start(ctx context.Context, events <-chan wal.RowEvent, ackCh ch
 				w.logger.Info("flushing all...")
 				return w.flushAll(context.Background(), ackCh)
 			}
+			if event.Op == wal.OpTruncate {
+				if err := w.truncate(ctx, event, ackCh); err != nil {
+					w.logger.Error("truncate error", "table", fmt.Sprintf("%s.%s", event.Schema, event.Table), "error", err)
+					return err
+				}
+				continue
+			}
 			transitioned := w.buffer(event)
 
 			key := fmt.Sprintf("%s.%s", event.Schema, event.Table)
@@ -325,6 +332,72 @@ func (w *Writer) flush(ctx context.Context, key string, ackCh chan<- pglogrepl.L
 	// so the consumer can advance its standby ack.
 	w.sendPendingMin(ackCh)
 
+	return nil
+}
+
+// truncate handles a TRUNCATE event for a single table by committing an
+// empty-replacement Iceberg snapshot at the TRUNCATE's LSN.
+//
+// Any rows or deletes currently buffered for the table are discarded —
+// a TRUNCATE that arrives after buffered INSERTs obliterates those
+// INSERTs anyway, and any INSERTs that arrive *after* the TRUNCATE are
+// already tagged with a later LSN and land in a fresh buffer.
+//
+// If the table has never been flushed yet (no Iceberg table on disk),
+// the TRUNCATE is a no-op: there is nothing to erase, and the next
+// INSERT will create the table from scratch.
+func (w *Writer) truncate(ctx context.Context, event wal.RowEvent, ackCh chan<- pglogrepl.LSN) error {
+	key := fmt.Sprintf("%s.%s", event.Schema, event.Table)
+	start := time.Now()
+
+	// Drop any in-flight state for this table. The rows are about to
+	// be erased by the snapshot we're about to write, so there is
+	// nothing to preserve.
+	if buf, exists := w.buffers[key]; exists {
+		buf.Rows = nil
+		buf.Deletes = nil
+		buf.FirstLSN = 0
+		if event.WALStartLSN > buf.LastLSN {
+			buf.LastLSN = event.WALStartLSN
+		}
+	}
+
+	tableExists, err := w.catalog.TableExists(ctx, event.Schema, event.Table)
+	if err != nil {
+		return fmt.Errorf("check table %s for truncate: %w", key, err)
+	}
+	if !tableExists {
+		w.logger.Info("truncate on not-yet-created table, no-op",
+			"table", key,
+			"lsn", event.WALStartLSN.String(),
+		)
+		// Still advance durable LSN so restart dedup doesn't replay
+		// this TRUNCATE and any pre-TRUNCATE events forever.
+		if err := w.state.UpdateLastFlush(event.WALStartLSN, event.Schema, event.Table); err != nil {
+			return fmt.Errorf("update last_flush after no-op truncate for %s: %w", key, err)
+		}
+		w.sendPendingMin(ackCh)
+		return nil
+	}
+
+	// replace=true, dataFile=nil → catalog writes an empty-manifest
+	// snapshot via commitEmptyTable. This is exactly "the table is
+	// now empty" in Iceberg terms.
+	if err := w.catalog.CommitChangeset(ctx, event.Schema, event.Table, nil, nil, true); err != nil {
+		return fmt.Errorf("commit empty snapshot for truncate %s: %w", key, err)
+	}
+
+	if err := w.state.UpdateLastFlush(event.WALStartLSN, event.Schema, event.Table); err != nil {
+		return fmt.Errorf("update last_flush after truncate for %s: %w", key, err)
+	}
+
+	w.logger.Info("truncate committed",
+		"table", key,
+		"lsn", event.WALStartLSN.String(),
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+
+	w.sendPendingMin(ackCh)
 	return nil
 }
 

--- a/internal/wal/consumer.go
+++ b/internal/wal/consumer.go
@@ -329,6 +329,28 @@ func (c *Consumer) Start(ctx context.Context, events chan<- RowEvent, ackCh <-ch
 					return err
 				}
 
+			case *TruncateMessage:
+				c.logger.Info("received truncate message",
+					"lsn", xld.WALStart.String(),
+					"relations", len(v.RelationIDs),
+				)
+				for _, relID := range v.RelationIDs {
+					rel, ok := shouldProcess(relID)
+					if !ok {
+						continue
+					}
+					if err := sendEvent(RowEvent{
+						Schema:      rel.Namespace,
+						Table:       rel.Name,
+						Columns:     rel.Columns,
+						KeyColumns:  rel.KeyColumnIndexes,
+						Op:          OpTruncate,
+						WALStartLSN: xld.WALStart,
+					}); err != nil {
+						return err
+					}
+				}
+
 			case *pglogrepl.CommitMessage:
 				c.logger.Info("received commit message", "commitLSN", v.CommitLSN.String())
 

--- a/internal/wal/decoder.go
+++ b/internal/wal/decoder.go
@@ -48,8 +48,7 @@ func (d *Decoder) Decode(msg pglogrepl.Message) (interface{}, error) {
 		return d.decodeDelete(m)
 
 	case *pglogrepl.TruncateMessage:
-		d.logger.Warn("TRUNCATE message received, skipping (Phase 2)")
-		return nil, nil
+		return d.decodeTruncate(m), nil
 
 	case *pglogrepl.TypeMessage:
 		return nil, nil
@@ -174,6 +173,21 @@ func (d *Decoder) decodeUpdate(m *pglogrepl.UpdateMessage) (*UpdateMessage, erro
 		OldKey:     oldKey,
 		NewRow:     newRow,
 	}, nil
+}
+
+// decodeTruncate captures the list of relations affected by a pgoutput
+// Truncate message. Unknown relation IDs are logged and dropped here so
+// the consumer only sees relations we have metadata for.
+func (d *Decoder) decodeTruncate(m *pglogrepl.TruncateMessage) *TruncateMessage {
+	ids := make([]uint32, 0, len(m.RelationIDs))
+	for _, relID := range m.RelationIDs {
+		if _, ok := d.relations[relID]; !ok {
+			d.logger.Warn("TRUNCATE for unknown relation, dropping", "relation_id", relID)
+			continue
+		}
+		ids = append(ids, relID)
+	}
+	return &TruncateMessage{RelationIDs: ids}
 }
 
 // decodeDelete extracts the key tuple from a pgoutput delete message.

--- a/internal/wal/decoder_test.go
+++ b/internal/wal/decoder_test.go
@@ -360,6 +360,70 @@ func TestDecodeDelete_NoOldTuple(t *testing.T) {
 	}
 }
 
+func TestDecodeTruncate_SingleTable(t *testing.T) {
+	d := testDecoder()
+	registerTwoColRelation(d, 10)
+
+	result, err := d.Decode(&pglogrepl.TruncateMessage{
+		RelationNum: 1,
+		RelationIDs: []uint32{10},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr, ok := result.(*TruncateMessage)
+	if !ok {
+		t.Fatalf("expected *TruncateMessage, got %T", result)
+	}
+	if len(tr.RelationIDs) != 1 || tr.RelationIDs[0] != 10 {
+		t.Errorf("RelationIDs=%v, want [10]", tr.RelationIDs)
+	}
+}
+
+func TestDecodeTruncate_MultiTable(t *testing.T) {
+	d := testDecoder()
+	registerTwoColRelation(d, 20)
+	d.Decode(&pglogrepl.RelationMessage{
+		RelationID:   21,
+		Namespace:    "public",
+		RelationName: "other",
+		Columns: []*pglogrepl.RelationMessageColumn{
+			{Flags: 1, Name: "id", DataType: 23},
+		},
+	})
+
+	result, err := d.Decode(&pglogrepl.TruncateMessage{
+		RelationNum: 2,
+		RelationIDs: []uint32{20, 21},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := result.(*TruncateMessage)
+	if len(tr.RelationIDs) != 2 {
+		t.Fatalf("expected 2 relations, got %d", len(tr.RelationIDs))
+	}
+}
+
+// A TRUNCATE carrying a relation the decoder hasn't seen yet is dropped
+// at decode time — the consumer only sees known relations.
+func TestDecodeTruncate_DropsUnknownRelation(t *testing.T) {
+	d := testDecoder()
+	registerTwoColRelation(d, 30)
+
+	result, err := d.Decode(&pglogrepl.TruncateMessage{
+		RelationNum: 2,
+		RelationIDs: []uint32{30, 99999},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := result.(*TruncateMessage)
+	if len(tr.RelationIDs) != 1 || tr.RelationIDs[0] != 30 {
+		t.Errorf("RelationIDs=%v, want [30]", tr.RelationIDs)
+	}
+}
+
 func TestDecodeUpdate_UnknownRelation(t *testing.T) {
 	d := testDecoder()
 	_, err := d.Decode(&pglogrepl.UpdateMessage{

--- a/internal/wal/types.go
+++ b/internal/wal/types.go
@@ -61,6 +61,13 @@ type DeleteMessage struct {
 	OldKey     []ColumnValue
 }
 
+// TruncateMessage represents a TRUNCATE affecting one or more tables.
+// A single pgoutput Truncate carries every relation that was truncated
+// in the same SQL statement (TRUNCATE a, b, c).
+type TruncateMessage struct {
+	RelationIDs []uint32
+}
+
 // Op identifies the kind of change a RowEvent represents.
 type Op uint8
 
@@ -68,6 +75,11 @@ const (
 	OpInsert Op = iota
 	OpUpdate
 	OpDelete
+	// OpTruncate represents a TRUNCATE of a single table. The event
+	// carries no row data; the writer handles it by discarding any
+	// buffered rows for the table and committing an empty-replacement
+	// Iceberg snapshot at the TRUNCATE's WAL position.
+	OpTruncate
 )
 
 func (o Op) String() string {
@@ -78,6 +90,8 @@ func (o Op) String() string {
 		return "UPDATE"
 	case OpDelete:
 		return "DELETE"
+	case OpTruncate:
+		return "TRUNCATE"
 	default:
 		return "UNKNOWN"
 	}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -614,6 +614,62 @@ func TestEndToEndUpdateDelete(t *testing.T) {
 	cleanup(t)
 }
 
+// TestEndToEndTruncate exercises TRUNCATE handling: rows are inserted and
+// flushed, then a TRUNCATE is replicated and the next sync must observe
+// a latest snapshot with zero rows. A final INSERT verifies the table is
+// still writable afterwards.
+func TestEndToEndTruncate(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+
+	cleanup(t)
+	clearS3Prefix(t)
+	setupTestTable(t)
+	execSQL(t, "ALTER TABLE test_events REPLICA IDENTITY FULL")
+
+	createSlotAndPublication(t)
+
+	sharedStatePath := t.TempDir() + "/state.db"
+
+	t.Log("inserting 20 rows...")
+	insertRows(t, 20)
+
+	t.Log("syncing initial inserts...")
+	runSync(t, ctx, 12*time.Second, sharedStatePath)
+
+	rows := countLatestSnapshotRows(t)
+	t.Logf("after insert: %d rows in latest snapshot", rows)
+	if rows != 20 {
+		t.Fatalf("expected 20 rows after insert, got %d", rows)
+	}
+
+	t.Log("TRUNCATE test_events...")
+	execSQL(t, "TRUNCATE test_events")
+
+	t.Log("syncing truncate...")
+	runSync(t, ctx, 12*time.Second, sharedStatePath)
+
+	rows = countLatestSnapshotRows(t)
+	t.Logf("after truncate: %d rows in latest snapshot", rows)
+	if rows != 0 {
+		t.Fatalf("expected 0 rows after truncate, got %d", rows)
+	}
+
+	t.Log("inserting 5 fresh rows after truncate...")
+	insertRows(t, 5)
+
+	t.Log("syncing post-truncate inserts...")
+	runSync(t, ctx, 12*time.Second, sharedStatePath)
+
+	rows = countLatestSnapshotRows(t)
+	t.Logf("after post-truncate insert: %d rows in latest snapshot", rows)
+	if rows != 5 {
+		t.Fatalf("expected 5 rows after post-truncate insert, got %d", rows)
+	}
+
+	cleanup(t)
+}
+
 // execSQL runs a single SQL statement against postgres.
 func execSQL(t *testing.T, sql string) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- Postgres pgoutput TRUNCATE messages were silently dropped, causing row-count drift (e.g. pgbench `-i` reinitialize left stale rows in Iceberg)
- Decoder now emits typed `TruncateMessage`, consumer fans out per-table `OpTruncate` events, writer commits an empty-replacement Iceberg snapshot via the existing `commitEmptyTable` path
- In-flight buffer for the truncated table is discarded before the empty snapshot commit; never-flushed tables short-circuit to no-op but still advance `last_flush_lsn`

## Test plan
- [x] 3 new decoder unit tests: single table, multi-table, unknown-relation drop
- [x] `TestEndToEndTruncate` integration test: insert 20 → sync → TRUNCATE → sync → 0 rows → insert 5 → sync → 5 rows
- [x] Regression: `TestEndToEnd`, `TestEndToEndUpdateDelete`, `TestEndToEndResume` all pass
- [x] `go build ./...` and `go vet ./...` clean

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)