### PR TITLE
feat: Iceberg as sole source of truth for last_flush_lsn

### DIFF
--- a/cmd/streambed/main.go
+++ b/cmd/streambed/main.go
@@ -247,42 +247,66 @@ func runSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("setup replication slot: %w", err)
 	}
 
-	// Check state store for last flushed LSN (may be more recent than slot)
-	stateLSN, err := stateStore.GetFlushedLSN()
+	// Initialize Iceberg catalog
+	catalog := iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
+
+	// Read per-table flush LSNs from Iceberg (the sole source of truth).
+	// These are used for dedup on restart and to determine startLSN.
+	tableFlushLSN := make(map[string]pglogrepl.LSN)
+	registeredTables, err := stateStore.GetRegisteredTables()
 	if err != nil {
-		return fmt.Errorf("get flushed LSN from state: %w", err)
+		return fmt.Errorf("get registered tables: %w", err)
 	}
-	var minStoreLsn pglogrepl.LSN
-	for _, lsnStr := range stateLSN {
+	for _, t := range registeredTables {
+		exists, err := catalog.TableExists(ctx, t.Schema, t.Table)
+		if err != nil {
+			return fmt.Errorf("check table %s.%s: %w", t.Schema, t.Table, err)
+		}
+		if !exists {
+			continue
+		}
+		lsnStr, found, err := catalog.GetSnapshotFlushLSN(ctx, t.Schema, t.Table)
+		if err != nil {
+			logger.Warn("cannot read Iceberg LSN, skipping",
+				"table", fmt.Sprintf("%s.%s", t.Schema, t.Table),
+				"error", err,
+			)
+			continue
+		}
+		if !found {
+			continue
+		}
 		lsn, err := pglogrepl.ParseLSN(lsnStr)
 		if err != nil {
-			return fmt.Errorf("error parsing LSN: %s %v", lsnStr, err)
+			return fmt.Errorf("parse Iceberg LSN %q for %s.%s: %w", lsnStr, t.Schema, t.Table, err)
 		}
-		if minStoreLsn > lsn || minStoreLsn == 0 {
-			minStoreLsn = lsn
+		tableFlushLSN[fmt.Sprintf("%s.%s", t.Schema, t.Table)] = lsn
+	}
+
+	var minIcebergLSN pglogrepl.LSN
+	for _, lsn := range tableFlushLSN {
+		if minIcebergLSN == 0 || lsn < minIcebergLSN {
+			minIcebergLSN = lsn
 		}
 	}
 
 	startLSN := slotLSN
-	if minStoreLsn > startLSN {
-		startLSN = minStoreLsn
-		logger.Info("resuming from state store LSN", "lsn", startLSN)
-	} else if minStoreLsn < startLSN && minStoreLsn != 0 {
-		logger.Warn("state store is behind slot position, some data may need re-sync",
-			"min_store_lsn", minStoreLsn,
+	if minIcebergLSN > startLSN {
+		startLSN = minIcebergLSN
+		logger.Info("resuming from Iceberg LSN", "lsn", startLSN)
+	} else if minIcebergLSN < startLSN && minIcebergLSN != 0 {
+		logger.Warn("Iceberg is behind slot position, some data may need re-sync",
+			"min_iceberg_lsn", minIcebergLSN,
 			"slot_lsn", startLSN,
 		)
 	}
-
-	// Initialize Iceberg catalog
-	catalog := iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
 
 	// Initialize writer
 	writer := iceberg.NewWriter(catalog, s3Client, stateStore, cfg.SlotName,
 		cfg.FlushRows, cfg.FlushInterval, logger)
 
 	// Create consumer
-	consumer := wal.NewConsumer(pgConn, cfg.SlotName, pubName, startLSN, cfg.ExcludeTables, logger, stateStore)
+	consumer := wal.NewConsumer(pgConn, cfg.SlotName, pubName, startLSN, cfg.ExcludeTables, logger, stateStore, tableFlushLSN)
 
 	// Channels
 	events := make(chan wal.RowEvent, 1000)

--- a/internal/iceberg/catalog.go
+++ b/internal/iceberg/catalog.go
@@ -202,8 +202,8 @@ func (c *Catalog) GetDataFilePaths(ctx context.Context, schema, table string) ([
 // CommitSnapshot appends a new data file via a new Iceberg snapshot.
 // This is a thin wrapper around CommitChangeset for append-only callers
 // (see resync and initial backfill paths).
-func (c *Catalog) CommitSnapshot(ctx context.Context, schema, table string, dataFile DataFile) error {
-	return c.CommitChangeset(ctx, schema, table, &dataFile, nil, false)
+func (c *Catalog) CommitSnapshot(ctx context.Context, schema, table string, dataFile DataFile, flushLSN string) error {
+	return c.CommitChangeset(ctx, schema, table, &dataFile, nil, false, flushLSN)
 }
 
 // CommitChangeset atomically adds one snapshot that may contain a data
@@ -233,6 +233,7 @@ func (c *Catalog) CommitChangeset(
 	dataFile *DataFile,
 	eqDel *EqDeleteFile,
 	replace bool,
+	flushLSN string,
 ) error {
 	if dataFile == nil && eqDel == nil && !replace {
 		return fmt.Errorf("commit changeset: both data and delete are nil")
@@ -241,7 +242,7 @@ func (c *Catalog) CommitChangeset(
 	// COW with no data file at all (shouldn't happen now that the writer
 	// always writes a Parquet file, but kept as a safety net).
 	if replace && dataFile == nil {
-		return c.commitEmptyTable(ctx, schema, table)
+		return c.commitEmptyTable(ctx, schema, table, flushLSN)
 	}
 	basePath := c.tablePath(schema, table)
 
@@ -391,6 +392,9 @@ func (c *Catalog) CommitChangeset(
 	default:
 		summary["operation"] = "append"
 	}
+	if flushLSN != "" {
+		summary["streambed.last_flush_lsn"] = flushLSN
+	}
 	if replace {
 		// Overwrite: total-records is just what's in this snapshot.
 		summary["total-records"] = strconv.FormatInt(addedRows, 10)
@@ -441,7 +445,7 @@ func (c *Catalog) CommitChangeset(
 // effectively marking the table as "exists but has no data". This is used when
 // a COW delete removes all rows — it avoids both iceberg-go's record_count>0
 // validation and DuckDB's empty-manifest-list crash.
-func (c *Catalog) commitEmptyTable(ctx context.Context, schema, table string) error {
+func (c *Catalog) commitEmptyTable(ctx context.Context, schema, table, flushLSN string) error {
 	basePath := c.tablePath(schema, table)
 
 	hintKey := path.Join(basePath, "metadata", "version-hint.text")
@@ -475,6 +479,15 @@ func (c *Catalog) commitEmptyTable(ctx context.Context, schema, table string) er
 	metadata.Snapshots = []snapshot{}
 	metadata.SnapshotLog = []snapshotLogEntry{}
 	metadata.Refs = map[string]interface{}{}
+	// Persist flushLSN in table properties since there are no snapshots
+	// to carry it in the summary. GetSnapshotFlushLSN reads this as a
+	// fallback when current-snapshot-id == -1.
+	if flushLSN != "" {
+		if metadata.Properties == nil {
+			metadata.Properties = map[string]string{}
+		}
+		metadata.Properties["streambed.last_flush_lsn"] = flushLSN
+	}
 	metadata.MetadataLog = append(metadata.MetadataLog, metadataLogEntry{
 		TimestampMS:  metadata.LastUpdatedMS,
 		MetadataFile: fmt.Sprintf("s3://%s/%s", c.bucket, currentMetaKey),
@@ -490,6 +503,53 @@ func (c *Catalog) commitEmptyTable(ctx context.Context, schema, table string) er
 		return err
 	}
 	return c.storage.PutObject(ctx, hintKey, []byte(strconv.Itoa(newVersion)), "text/plain")
+}
+
+// GetSnapshotFlushLSN reads the streambed.last_flush_lsn from the current
+// Iceberg snapshot's summary (or from table properties for empty tables).
+// Returns ("", false, nil) if the table exists but has no recorded LSN.
+// Returns an error if the table doesn't exist or metadata is unreadable.
+func (c *Catalog) GetSnapshotFlushLSN(ctx context.Context, schema, table string) (string, bool, error) {
+	basePath := c.tablePath(schema, table)
+
+	hintKey := path.Join(basePath, "metadata", "version-hint.text")
+	hintData, err := c.storage.GetObject(ctx, hintKey)
+	if err != nil {
+		return "", false, fmt.Errorf("read version-hint: %w", err)
+	}
+	version, err := strconv.Atoi(string(hintData))
+	if err != nil {
+		return "", false, fmt.Errorf("parse version hint: %w", err)
+	}
+
+	metaKey := path.Join(basePath, "metadata", fmt.Sprintf("v%d.metadata.json", version))
+	metaData, err := c.storage.GetObject(ctx, metaKey)
+	if err != nil {
+		return "", false, fmt.Errorf("read metadata: %w", err)
+	}
+	var metadata tableMetadata
+	if err := json.Unmarshal(metaData, &metadata); err != nil {
+		return "", false, fmt.Errorf("parse metadata: %w", err)
+	}
+
+	// Empty table (post-TRUNCATE / commitEmptyTable): LSN is in properties.
+	if metadata.CurrentSnapshotID <= 0 {
+		if lsn, ok := metadata.Properties["streambed.last_flush_lsn"]; ok {
+			return lsn, true, nil
+		}
+		return "", false, nil
+	}
+
+	// Find current snapshot and read summary.
+	for _, snap := range metadata.Snapshots {
+		if snap.SnapshotID == metadata.CurrentSnapshotID {
+			if lsn, ok := snap.Summary["streambed.last_flush_lsn"]; ok {
+				return lsn, true, nil
+			}
+			return "", false, nil
+		}
+	}
+	return "", false, nil
 }
 
 // readManifestList reads a manifest list Avro file using iceberg-go.

--- a/internal/iceberg/writer.go
+++ b/internal/iceberg/writer.go
@@ -136,7 +136,7 @@ func (w *Writer) buffer(event wal.RowEvent) bool {
 		w.buffers[key] = buf
 
 		// Register table in state store
-		w.state.RegisterTable(event.Schema, event.Table, len(event.Columns), event.WALStartLSN)
+		w.state.RegisterTable(event.Schema, event.Table, len(event.Columns))
 		w.logger.Info("new table discovered",
 			"schema", event.Schema,
 			"table", event.Table,
@@ -298,14 +298,8 @@ func (w *Writer) flush(ctx context.Context, key string, ackCh chan<- pglogrepl.L
 	}
 
 	// Commit snapshot.
-	if err := w.catalog.CommitChangeset(ctx, buf.Schema, buf.Table, dataFile, nil, replace); err != nil {
+	if err := w.catalog.CommitChangeset(ctx, buf.Schema, buf.Table, dataFile, nil, replace, buf.LastLSN.String()); err != nil {
 		return fmt.Errorf("commit snapshot for %s: %w", key, err)
-	}
-
-	w.logger.Info("syncing last LSN to state", "LSN", buf.LastLSN.String())
-
-	if err := w.state.UpdateLastFlush(buf.LastLSN, buf.Schema, buf.Table); err != nil {
-		return fmt.Errorf("unable to set flushed LSN in the store %s: %w", buf.LastLSN.String(), err)
 	}
 
 	duration := time.Since(start)
@@ -371,11 +365,6 @@ func (w *Writer) truncate(ctx context.Context, event wal.RowEvent, ackCh chan<- 
 			"table", key,
 			"lsn", event.WALStartLSN.String(),
 		)
-		// Still advance durable LSN so restart dedup doesn't replay
-		// this TRUNCATE and any pre-TRUNCATE events forever.
-		if err := w.state.UpdateLastFlush(event.WALStartLSN, event.Schema, event.Table); err != nil {
-			return fmt.Errorf("update last_flush after no-op truncate for %s: %w", key, err)
-		}
 		w.sendPendingMin(ackCh)
 		return nil
 	}
@@ -383,12 +372,8 @@ func (w *Writer) truncate(ctx context.Context, event wal.RowEvent, ackCh chan<- 
 	// replace=true, dataFile=nil → catalog writes an empty-manifest
 	// snapshot via commitEmptyTable. This is exactly "the table is
 	// now empty" in Iceberg terms.
-	if err := w.catalog.CommitChangeset(ctx, event.Schema, event.Table, nil, nil, true); err != nil {
+	if err := w.catalog.CommitChangeset(ctx, event.Schema, event.Table, nil, nil, true, event.WALStartLSN.String()); err != nil {
 		return fmt.Errorf("commit empty snapshot for truncate %s: %w", key, err)
-	}
-
-	if err := w.state.UpdateLastFlush(event.WALStartLSN, event.Schema, event.Table); err != nil {
-		return fmt.Errorf("update last_flush after truncate for %s: %w", key, err)
 	}
 
 	w.logger.Info("truncate committed",

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -158,7 +158,7 @@ func Run(ctx context.Context, opts Options) (Stats, error) {
 			Path:     dataFileName,
 			RowCount: int64(len(batch)),
 			FileSize: int64(len(parquetData)),
-		}); err != nil {
+		}, tmp.ConsistentPoint.String()); err != nil {
 			return fmt.Errorf("commit snapshot: %w", err)
 		}
 		stats.Batches++
@@ -211,11 +211,8 @@ func Run(ctx context.Context, opts Options) (Stats, error) {
 
 	// 5. Register the table in state (or refresh column count) and record
 	//    the backfill LSN so the sync consumer filters overlapping events.
-	if err := opts.State.RegisterTable(opts.Schema, opts.Table, len(columns), tmp.ConsistentPoint); err != nil {
+	if err := opts.State.RegisterTable(opts.Schema, opts.Table, len(columns)); err != nil {
 		return stats, fmt.Errorf("register table in state: %w", err)
-	}
-	if err := opts.State.UpdateLastFlush(tmp.ConsistentPoint, opts.Schema, opts.Table); err != nil {
-		return stats, fmt.Errorf("update last_flush: %w", err)
 	}
 	if err := opts.State.SetBackfillLSN(opts.Schema, opts.Table, tmp.ConsistentPoint); err != nil {
 		return stats, fmt.Errorf("set backfill_lsn: %w", err)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/jackc/pglogrepl"
 	_ "github.com/mattn/go-sqlite3"
@@ -102,70 +101,43 @@ func containsCI(s, sub string) bool {
 	return false
 }
 
-func (s *Store) GetFlushedLSN() (map[string]string, error) {
+
+func (s *Store) RegisterTable(schema, table string, columnCount int) error {
+	_, err := s.db.Exec(`
+		INSERT INTO synced_tables (schema_name, table_name, column_count)
+		VALUES (?, ?, ?)
+		ON CONFLICT(schema_name, table_name) DO UPDATE SET column_count = ?
+	`, schema, table, columnCount, columnCount)
+	return err
+}
+
+
+// RegisteredTable holds a registered table's schema and name.
+type RegisteredTable struct {
+	Schema string
+	Table  string
+}
+
+// GetRegisteredTables returns every table in synced_tables. Used at startup
+// to enumerate tables whose flush LSN should be read from Iceberg.
+func (s *Store) GetRegisteredTables() ([]RegisteredTable, error) {
 	rows, err := s.db.Query(
-		"SELECT table_name, last_flush_lsn FROM synced_tables where last_flush_lsn is NOT NULL",
+		"SELECT schema_name, table_name FROM synced_tables",
 	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	tableFlushLSN := make(map[string]string)
-	var tableName, last_flush_lsn string
 
+	var out []RegisteredTable
 	for rows.Next() {
-		if err := rows.Scan(&tableName, &last_flush_lsn); err != nil {
+		var t RegisteredTable
+		if err := rows.Scan(&t.Schema, &t.Table); err != nil {
 			return nil, err
 		}
-		tableFlushLSN[tableName] = last_flush_lsn
+		out = append(out, t)
 	}
-
-	return tableFlushLSN, nil
-}
-
-func (s *Store) GetSafestFlushedLSN() (pglogrepl.LSN, error) {
-	var lsnStr string
-	// ideally we should find the minimum of last_flush_lsn_position
-	// since it's a string and need to be decoded to a position, I am using the last_flush timestamp
-	err := s.db.QueryRow(
-		"SELECT last_flush_lsn FROM synced_tables WHERE last_flush IS NOT NULL ORDER BY last_flush ASC LIMIT 1",
-	).Scan(&lsnStr)
-	if err == sql.ErrNoRows {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, err
-	}
-	lsn, err := pglogrepl.ParseLSN(lsnStr)
-	if err != nil {
-		return 0, fmt.Errorf("parse LSN %q: %w", lsnStr, err)
-	}
-	return lsn, nil
-}
-
-func (s *Store) SetFlushedLSN(slotName string, lsn pglogrepl.LSN) error {
-	_, err := s.db.Exec(`
-		INSERT INTO replication_state (slot_name, flushed_lsn, updated_at)
-		VALUES (?, ?, ?)
-		ON CONFLICT(slot_name) DO UPDATE SET flushed_lsn = ?, updated_at = ?
-	`, slotName, lsn.String(), time.Now().UTC(), lsn.String(), time.Now().UTC())
-	return err
-}
-
-func (s *Store) RegisterTable(schema, table string, columnCount int, lsn pglogrepl.LSN) error {
-	_, err := s.db.Exec(`
-		INSERT INTO synced_tables (schema_name, table_name, column_count, last_flush_lsn)
-		VALUES (?, ?, ?, ?)
-		ON CONFLICT(schema_name, table_name) DO UPDATE SET column_count = ?
-	`, schema, table, columnCount, lsn.String(), columnCount)
-	return err
-}
-
-func (s *Store) UpdateLastFlush(lsn pglogrepl.LSN, schema, table string) error {
-	_, err := s.db.Exec(`
-		UPDATE synced_tables SET last_flush = ?, last_flush_lsn = ? WHERE schema_name = ? AND table_name = ?
-	`, time.Now().UTC(), lsn.String(), schema, table)
-	return err
+	return out, rows.Err()
 }
 
 // DeleteTable removes the synced_tables row for the given schema.table.

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -19,120 +19,32 @@ func tempStore(t *testing.T) *Store {
 	return s
 }
 
-func TestGetFlushedLSN_Empty(t *testing.T) {
-	s := tempStore(t)
-	lsn, err := s.GetSafestFlushedLSN()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if lsn != 0 {
-		t.Errorf("expected LSN 0 for fresh store, got %s", lsn)
-	}
-}
-
-func TestSetAndGetFlushedLSN(t *testing.T) {
-	s := tempStore(t)
-	want, _ := pglogrepl.ParseLSN("0/1234ABCD")
-
-	if err := s.SetFlushedLSN("test_slot", want); err != nil {
-		t.Fatal(err)
-	}
-
-	// SetFlushedLSN writes to replication_state, GetFlushedLSN reads from synced_tables.
-	// To test the round-trip via synced_tables, register a table with the LSN and flush it.
-	if err := s.RegisterTable("public", "orders", 5, want); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.UpdateLastFlush(want, "public", "orders"); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := s.GetFlushedLSN()
-	if err != nil {
-		t.Fatal(err)
-	}
-	gotLSN, ok := got["orders"]
-	if !ok {
-		t.Fatal("expected orders in flushed LSN map")
-	}
-	if gotLSN != want.String() {
-		t.Errorf("expected LSN %s, got %s", want, gotLSN)
-	}
-}
-
-func TestSetFlushedLSN_Update(t *testing.T) {
-	s := tempStore(t)
-	lsn1, _ := pglogrepl.ParseLSN("0/100")
-	lsn2, _ := pglogrepl.ParseLSN("0/200")
-
-	s.SetFlushedLSN("slot", lsn1)
-	s.SetFlushedLSN("slot", lsn2)
-
-	// Verify via synced_tables round-trip
-	s.RegisterTable("public", "t", 1, lsn2)
-	s.UpdateLastFlush(lsn2, "public", "t")
-
-	got, _ := s.GetFlushedLSN()
-	gotLSN, ok := got["t"]
-	if !ok {
-		t.Fatal("expected table t in flushed LSN map")
-	}
-	if gotLSN != lsn2.String() {
-		t.Errorf("expected updated LSN %s, got %s", lsn2, gotLSN)
-	}
-}
-
 func TestRegisterTable(t *testing.T) {
 	s := tempStore(t)
-	lsn, _ := pglogrepl.ParseLSN("0/100")
-	if err := s.RegisterTable("public", "orders", 5, lsn); err != nil {
+	if err := s.RegisterTable("public", "orders", 5); err != nil {
 		t.Fatal(err)
 	}
 	// Update column count
-	if err := s.RegisterTable("public", "orders", 6, lsn); err != nil {
+	if err := s.RegisterTable("public", "orders", 6); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// TestRegisterTableStoresValidLSN verifies that RegisterTable stores the LSN
-// (not the column count) in last_flush_lsn. This catches the parameter-order
-// bug where columnCount was written as last_flush_lsn.
-func TestRegisterTableStoresValidLSN(t *testing.T) {
+func TestGetRegisteredTables(t *testing.T) {
 	s := tempStore(t)
-	lsn, _ := pglogrepl.ParseLSN("0/ABCD1234")
-
-	if err := s.RegisterTable("public", "events", 7, lsn); err != nil {
+	if err := s.RegisterTable("public", "orders", 5); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterTable("public", "events", 3); err != nil {
 		t.Fatal(err)
 	}
 
-	// GetFlushedLSN reads last_flush_lsn from synced_tables.
-	// If RegisterTable stored "7" (the column count) instead of "0/ABCD1234",
-	// ParseLSN will fail in the caller.
-	got, err := s.GetFlushedLSN()
+	tables, err := s.GetRegisteredTables()
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotLSN, ok := got["events"]
-	if !ok {
-		t.Fatal("expected events in flushed LSN map")
-	}
-
-	// Verify it's a valid LSN by parsing it.
-	parsed, err := pglogrepl.ParseLSN(gotLSN)
-	if err != nil {
-		t.Fatalf("RegisterTable stored invalid LSN %q (column count leaked?): %v", gotLSN, err)
-	}
-	if parsed != lsn {
-		t.Errorf("expected LSN %s, got %s", lsn, parsed)
-	}
-}
-
-func TestUpdateLastFlush(t *testing.T) {
-	s := tempStore(t)
-	lsn, _ := pglogrepl.ParseLSN("0/100")
-	s.RegisterTable("public", "orders", 5, lsn)
-	if err := s.UpdateLastFlush(lsn, "public", "orders"); err != nil {
-		t.Fatal(err)
+	if len(tables) != 2 {
+		t.Fatalf("expected 2 tables, got %d", len(tables))
 	}
 }
 
@@ -152,7 +64,7 @@ func TestBackfillLSN_SetGetClear(t *testing.T) {
 	lsn, _ := pglogrepl.ParseLSN("0/DEADBEEF")
 
 	// Must register table first (backfill_lsn is a column on synced_tables).
-	if err := s.RegisterTable("public", "orders", 5, lsn); err != nil {
+	if err := s.RegisterTable("public", "orders", 5); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,10 +101,10 @@ func TestBackfillLSN_MultipleTables(t *testing.T) {
 	lsnA, _ := pglogrepl.ParseLSN("0/100")
 	lsnB, _ := pglogrepl.ParseLSN("0/200")
 
-	if err := s.RegisterTable("public", "a", 1, lsnA); err != nil {
+	if err := s.RegisterTable("public", "a", 1); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.RegisterTable("public", "b", 1, lsnB); err != nil {
+	if err := s.RegisterTable("public", "b", 1); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/wal/consumer.go
+++ b/internal/wal/consumer.go
@@ -27,10 +27,15 @@ type Consumer struct {
 	logger        *slog.Logger
 	excludeTables map[string]bool
 	state         *state.Store
+	// tableFlushLSN holds the per-table last flushed LSN read from
+	// Iceberg at startup. Events with LSN <= this value are skipped
+	// (already flushed). Keyed by "schema.table".
+	tableFlushLSN map[string]pglogrepl.LSN
 }
 
-// NewConsumer creates a new WAL consumer.
-func NewConsumer(conn *pgconn.PgConn, slotName, publication string, startLSN pglogrepl.LSN, excludeTables []string, logger *slog.Logger, state *state.Store) *Consumer {
+// NewConsumer creates a new WAL consumer. tableFlushLSN is the per-table
+// last flushed LSN read from Iceberg at startup, keyed by "schema.table".
+func NewConsumer(conn *pgconn.PgConn, slotName, publication string, startLSN pglogrepl.LSN, excludeTables []string, logger *slog.Logger, state *state.Store, tableFlushLSN map[string]pglogrepl.LSN) *Consumer {
 	exclude := make(map[string]bool)
 	for _, t := range excludeTables {
 		exclude[t] = true
@@ -45,6 +50,7 @@ func NewConsumer(conn *pgconn.PgConn, slotName, publication string, startLSN pgl
 		logger:        logger,
 		excludeTables: exclude,
 		state:         state,
+		tableFlushLSN: tableFlushLSN,
 	}
 }
 
@@ -80,18 +86,7 @@ func (c *Consumer) Start(ctx context.Context, events chan<- RowEvent, ackCh <-ch
 	//       else min(receivedLSN, pendingMinLSN-1).
 	receivedLSN := c.startLSN
 	var pendingMinLSN pglogrepl.LSN
-	tableFlushLSN := make(map[string]pglogrepl.LSN)
-	flushLSN, err := c.state.GetFlushedLSN()
-	if err != nil {
-		return fmt.Errorf("error getting flush LSN for all tables: %w", err)
-	}
-	for table, lsnStr := range flushLSN {
-		lsn, err := pglogrepl.ParseLSN(lsnStr)
-		if err != nil {
-			return fmt.Errorf("parse LSN %q: %w", lsnStr, err)
-		}
-		tableFlushLSN[table] = lsn
-	}
+	tableFlushLSN := c.tableFlushLSN
 
 	// Load backfill filters. Any entry here means a resync has been
 	// performed for that table at snapshot LSN X; main-slot events whose
@@ -237,7 +232,7 @@ func (c *Consumer) Start(ctx context.Context, events chan<- RowEvent, ackCh <-ch
 						)
 					}
 				}
-				if storeLsn := tableFlushLSN[rel.Name]; storeLsn >= xld.WALStart {
+				if storeLsn := tableFlushLSN[key]; storeLsn >= xld.WALStart {
 					return rel, false
 				}
 				return rel, true

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -189,26 +189,39 @@ func runSync(t *testing.T, ctx context.Context, duration time.Duration, statePat
 		t.Fatalf("setup replication slot: %v", err)
 	}
 
-	// Check state store for safest flushed LSN
-	stateLSN, err := stateStore.GetSafestFlushedLSN()
-	if err != nil {
-		t.Fatalf("get flushed LSN: %v", err)
-	}
-
 	startLSN := slotLSN
-	if stateLSN > startLSN {
-		startLSN = stateLSN
-	}
 
 	// Initialize Iceberg catalog
 	catalog := iceberg.NewCatalog(s3Client, s3Bucket, s3Prefix)
+
+	// Read per-table flush LSNs from Iceberg for dedup on restart.
+	tableFlushLSN := make(map[string]pglogrepl.LSN)
+	registeredTables, err := stateStore.GetRegisteredTables()
+	if err != nil {
+		t.Fatalf("get registered tables: %v", err)
+	}
+	for _, rt := range registeredTables {
+		exists, err := catalog.TableExists(ctx, rt.Schema, rt.Table)
+		if err != nil || !exists {
+			continue
+		}
+		lsnStr, found, err := catalog.GetSnapshotFlushLSN(ctx, rt.Schema, rt.Table)
+		if err != nil || !found {
+			continue
+		}
+		lsn, err := pglogrepl.ParseLSN(lsnStr)
+		if err != nil {
+			continue
+		}
+		tableFlushLSN[fmt.Sprintf("%s.%s", rt.Schema, rt.Table)] = lsn
+	}
 
 	// Initialize writer
 	writer := iceberg.NewWriter(catalog, s3Client, stateStore, slotName,
 		flushRows, 5*time.Second, logger)
 
 	// Create consumer
-	consumer := wal.NewConsumer(pgConn, slotName, slotName, startLSN, nil, logger, stateStore)
+	consumer := wal.NewConsumer(pgConn, slotName, slotName, startLSN, nil, logger, stateStore, tableFlushLSN)
 
 	// Channels
 	events := make(chan wal.RowEvent, 1000)
@@ -666,6 +679,56 @@ func TestEndToEndTruncate(t *testing.T) {
 	if rows != 5 {
 		t.Fatalf("expected 5 rows after post-truncate insert, got %d", rows)
 	}
+
+	cleanup(t)
+}
+
+// TestEndToEndSnapshotSummaryLSN verifies that after a flush, the Iceberg
+// snapshot summary contains "streambed.last_flush_lsn" and that it can be
+// read back via GetSnapshotFlushLSN. This is the foundation for startup
+// reconciliation (Iceberg is the source of truth for dedup cursors).
+func TestEndToEndSnapshotSummaryLSN(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+
+	cleanup(t)
+	clearS3Prefix(t)
+	setupTestTable(t)
+	createSlotAndPublication(t)
+
+	sharedStatePath := t.TempDir() + "/state.db"
+
+	t.Log("inserting 10 rows...")
+	insertRows(t, 10)
+
+	t.Log("syncing...")
+	runSync(t, ctx, 12*time.Second, sharedStatePath)
+
+	// Read the snapshot summary LSN via the catalog
+	storageClient, err := storage.NewS3Client(ctx, s3Bucket, s3Region, minioEndpoint)
+	if err != nil {
+		t.Fatalf("create S3 client: %v", err)
+	}
+	catalog := iceberg.NewCatalog(storageClient, s3Bucket, s3Prefix)
+
+	lsnStr, found, err := catalog.GetSnapshotFlushLSN(ctx, "public", "test_events")
+	if err != nil {
+		t.Fatalf("GetSnapshotFlushLSN: %v", err)
+	}
+	if !found {
+		t.Fatal("expected streambed.last_flush_lsn in snapshot summary, not found")
+	}
+	if lsnStr == "" {
+		t.Fatal("streambed.last_flush_lsn is empty")
+	}
+	lsn, err := pglogrepl.ParseLSN(lsnStr)
+	if err != nil {
+		t.Fatalf("parse LSN %q from summary: %v", lsnStr, err)
+	}
+	if lsn == 0 {
+		t.Fatal("streambed.last_flush_lsn is zero")
+	}
+	t.Logf("snapshot summary streambed.last_flush_lsn = %s", lsn)
 
 	cleanup(t)
 }


### PR DESCRIPTION
## Summary
- Write `streambed.last_flush_lsn` to Iceberg snapshot summary on every commit (and table properties for empty/truncated tables)
- On startup, read per-table flush LSN from Iceberg instead of SQLite — Iceberg is now the sole source of truth
- Remove `UpdateLastFlush`/`GetFlushedLSN`/`GetSafestFlushedLSN` from the state store (dead code)
- Fix dedup key from `table` to `schema.table` (was a latent bug for multi-schema setups)

## Test plan
- [x] All 5 integration tests pass (TestEndToEnd, TestEndToEndUpdateDelete, TestEndToEndTruncate, TestEndToEndSnapshotSummaryLSN, TestEndToEndResume)
- [x] Unit tests pass for state, wal, and iceberg packages
- [x] `go build ./...` and `go vet ./...` clean