### PR TITLE
ci: fix Hugo module fetch in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Fetch Hugo modules
         working-directory: site
-        run: hugo mod download
+        run: go mod download
 
       - name: Build site
         working-directory: site


### PR DESCRIPTION
## Summary
- \`hugo mod download\` isn't a real subcommand — deploy was failing on that step
- Swap to \`go mod download\` which resolves modules at versions pinned in \`go.mod\`/\`go.sum\` without upgrading

## Test plan
- [ ] Deploy workflow succeeds on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)