### PR TITLE
Fix COW delete-all empty commits

### DIFF
--- a/internal/iceberg/catalog.go
+++ b/internal/iceberg/catalog.go
@@ -557,9 +557,10 @@ func (c *Catalog) CommitChangeset(
 		return fmt.Errorf("commit changeset: both data and delete are nil")
 	}
 
-	// COW with no data file at all (shouldn't happen now that the writer
-	// always writes a Parquet file, but kept as a safety net).
-	if replace && dataFile == nil {
+	// COW replacement with no rows means the table is logically empty. Do not
+	// publish a zero-row data manifest: iceberg-go rejects true 0-row entries,
+	// and advertising a fake row count can make readers retain a ghost row.
+	if replace && (dataFile == nil || dataFile.RowCount == 0) {
 		return c.commitEmptyTable(ctx, schema, table, flushLSN)
 	}
 	basePath := c.tablePath(schema, table)

--- a/internal/iceberg/writer.go
+++ b/internal/iceberg/writer.go
@@ -492,17 +492,17 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 		buf.Deletes = nil
 	}
 
-	// COW writes an empty replacement file when all rows were removed so
-	// DuckDB can still query the table. MOR delete-only commits need no data
-	// file: the equality-delete file is sufficient.
-	if len(dataRows) > 0 || (replace && delCount > 0) {
+	// COW delete-all commits use the catalog's empty-table metadata path.
+	// MOR delete-only commits need no data file: the equality-delete file is
+	// sufficient.
+	if len(dataRows) > 0 {
 		dataFile, err = w.writeDataFile(ctx, key, buf, cols, dataRows)
 		if err != nil {
 			return err
 		}
 	}
 
-	if dataFile == nil && eqDeleteFile == nil {
+	if dataFile == nil && eqDeleteFile == nil && !replace {
 		return fmt.Errorf("flush %s produced no data or delete file", key)
 	}
 

--- a/internal/iceberg/writer_test.go
+++ b/internal/iceberg/writer_test.go
@@ -518,6 +518,66 @@ func TestFlushCOW(t *testing.T) {
 	}
 }
 
+func TestFlushCOWLargeBatchedDeleteAllCommitsEmptyTable(t *testing.T) {
+	w, mem := testWriter(t)
+	w.flushRows = 100
+	ctx := context.Background()
+
+	const totalRows = 250
+	for i := 1; i <= totalRows; i++ {
+		if _, err := w.HandleEvent(ctx, insertEvent("public", "accounts", pglogrepl.LSN(i), strconv.Itoa(i), "live")); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("flush inserts: %v", err)
+	}
+
+	for i := 1; i <= totalRows; i++ {
+		lsn := pglogrepl.LSN(1000 + i)
+		if _, err := w.HandleEvent(ctx, deleteEvent("public", "accounts", lsn, strconv.Itoa(i))); err != nil {
+			t.Fatalf("delete %d: %v", i, err)
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("flush final partial deletes: %v", err)
+	}
+
+	paths, err := w.catalog.GetDataFilePaths(ctx, "public", "accounts")
+	if err != nil {
+		t.Fatalf("GetDataFilePaths: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("current data files=%d, want none for empty COW table: %v", len(paths), paths)
+	}
+
+	hint, err := mem.GetObject(ctx, "test-prefix/public/accounts/metadata/version-hint.text")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metaData, err := mem.GetObject(ctx, fmt.Sprintf("test-prefix/public/accounts/metadata/v%s.metadata.json", hint))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta tableMetadata
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.CurrentSnapshotID != -1 {
+		t.Fatalf("current-snapshot-id=%d, want -1", meta.CurrentSnapshotID)
+	}
+	if len(meta.Snapshots) != 0 {
+		t.Fatalf("snapshots=%d, want none in empty-table metadata", len(meta.Snapshots))
+	}
+	lsn, found, err := w.catalog.GetSnapshotFlushLSN(ctx, "public", "accounts")
+	if err != nil {
+		t.Fatalf("GetSnapshotFlushLSN: %v", err)
+	}
+	if !found || lsn != pglogrepl.LSN(1000+totalRows).String() {
+		t.Fatalf("flush LSN=(%q,%v), want %s", lsn, found, pglogrepl.LSN(1000+totalRows))
+	}
+}
+
 func TestFlushMORWritesEqualityDeletesWithoutReadingData(t *testing.T) {
 	for _, tc := range []struct {
 		mode          MutationMode


### PR DESCRIPTION
## Summary

Fixes #30 by making COW delete-all flushes commit Streambed's explicit empty-table metadata state instead of publishing a zero-row replacement Parquet data file.

## Root Cause

The writer still emitted a replacement data file for COW batches where deletes removed every row. The catalog then had to advertise a non-zero manifest row count for the zero-row file to satisfy Iceberg metadata validation, which could leave readers with a ghost row after large batched DELETE workloads.

## Changes

- Route COW replacements with `nil` or zero-row data files to `commitEmptyTable`.
- Stop writing a zero-row replacement Parquet file from the COW delete-all writer path.
- Add a writer regression that inserts 250 rows, deletes all rows with `flushRows=100`, flushes the final partial batch, and asserts the table has no current data files and empty-table metadata.

## Validation

- `go test ./internal/iceberg`
- `go test ./...`