### PR TITLE
Optimize COW layout and maintenance

### DIFF
--- a/cmd/streambed/main.go
+++ b/cmd/streambed/main.go
@@ -53,6 +53,7 @@ func main() {
 	syncCmd.Flags().StringVar(&cfg.SlotName, "slot-name", cfg.SlotName, "Replication slot name")
 	syncCmd.Flags().IntVar(&cfg.FlushRows, "flush-rows", cfg.FlushRows, "Row buffer flush threshold")
 	syncCmd.Flags().DurationVar(&cfg.FlushInterval, "flush-interval", cfg.FlushInterval, "Time-based flush interval")
+	syncCmd.Flags().IntVar(&cfg.TargetFileSizeMB, "target-file-size-mb", cfg.TargetFileSizeMB, "Target compressed Parquet data file size in MiB")
 	syncCmd.Flags().StringSliceVar(&cfg.IncludeTables, "include-tables", cfg.IncludeTables, "Tables to include")
 	syncCmd.Flags().StringSliceVar(&cfg.ExcludeTables, "exclude-tables", cfg.ExcludeTables, "Tables to exclude")
 	syncCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
@@ -97,6 +98,29 @@ This command does NOT touch the Postgres replication slot.`,
 	cleanupCmd.Flags().StringVar(&cfg.StatePath, "state-path", cfg.StatePath, "SQLite state file path")
 	cleanupCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
 
+	var maintenanceTables []string
+	var maintenanceRetainLast int
+	var maintenanceOrphans bool
+	var maintenanceDryRun bool
+	var maintenanceForce bool
+	maintenanceCmd := &cobra.Command{
+		Use:   "maintenance",
+		Short: "Expire Iceberg snapshots and clean orphan files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMaintenance(cmd, maintenanceTables, maintenanceRetainLast, maintenanceOrphans, maintenanceDryRun, maintenanceForce)
+		},
+	}
+	maintenanceCmd.Flags().StringSliceVar(&maintenanceTables, "table", nil, "Table to maintain as schema.table (repeatable, required)")
+	maintenanceCmd.Flags().IntVar(&maintenanceRetainLast, "retain-last", 1, "Number of non-current historical snapshots to retain")
+	maintenanceCmd.Flags().BoolVar(&maintenanceOrphans, "orphans", false, "Also delete orphan objects unreachable from retained metadata")
+	maintenanceCmd.Flags().BoolVar(&maintenanceDryRun, "dry-run", true, "Only print planned deletions")
+	maintenanceCmd.Flags().BoolVar(&maintenanceForce, "force", false, "Apply deletions; required with --dry-run=false")
+	maintenanceCmd.Flags().StringVar(&cfg.S3Bucket, "s3-bucket", cfg.S3Bucket, "S3 bucket name")
+	maintenanceCmd.Flags().StringVar(&cfg.S3Prefix, "s3-prefix", cfg.S3Prefix, "S3 key prefix")
+	maintenanceCmd.Flags().StringVar(&cfg.S3Endpoint, "s3-endpoint", cfg.S3Endpoint, "Custom S3 endpoint (MinIO)")
+	maintenanceCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
+	maintenanceCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
+
 	var resyncTable string
 	var resyncForce bool
 	resyncCmd := &cobra.Command{
@@ -123,7 +147,7 @@ snapshot LSN are silently discarded for this table to avoid duplicates.`,
 	resyncCmd.Flags().IntVar(&cfg.FlushRows, "flush-rows", cfg.FlushRows, "Rows per parquet file / Iceberg snapshot")
 	resyncCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
 
-	rootCmd.AddCommand(syncCmd, queryCmd, cleanupCmd, resyncCmd)
+	rootCmd.AddCommand(syncCmd, queryCmd, cleanupCmd, maintenanceCmd, resyncCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -154,6 +178,8 @@ func runSync(cmd *cobra.Command, args []string) error {
 			cfg.FlushRows, _ = cmd.Flags().GetInt("flush-rows")
 		case "flush-interval":
 			cfg.FlushInterval, _ = cmd.Flags().GetDuration("flush-interval")
+		case "target-file-size-mb":
+			cfg.TargetFileSizeMB, _ = cmd.Flags().GetInt("target-file-size-mb")
 		case "include-tables":
 			cfg.IncludeTables, _ = cmd.Flags().GetStringSlice("include-tables")
 		case "exclude-tables":
@@ -180,6 +206,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		"slot", cfg.SlotName,
 		"flush_rows", cfg.FlushRows,
 		"flush_interval", cfg.FlushInterval,
+		"target_file_size_mb", cfg.TargetFileSizeMB,
 		"mutation_mode", cfg.MutationMode,
 	)
 
@@ -333,7 +360,8 @@ func runSync(cmd *cobra.Command, args []string) error {
 	// Initialize writer
 	writer := iceberg.NewWriter(catalog, s3Client, stateStore, cfg.SlotName,
 		cfg.FlushRows, cfg.FlushInterval, logger,
-		iceberg.WithMutationMode(iceberg.MutationMode(cfg.MutationMode)))
+		iceberg.WithMutationMode(iceberg.MutationMode(cfg.MutationMode)),
+		iceberg.WithTargetFileSizeBytes(int64(cfg.TargetFileSizeMB)*1024*1024))
 
 	// Create unified pipeline (single goroutine: reads WAL + writes Iceberg)
 	p := pipeline.New(pgConn, cfg.SlotName, pubName, startLSN, cfg.ExcludeTables,
@@ -424,7 +452,8 @@ func runSync(cmd *cobra.Command, args []string) error {
 		// Recreate writer and pipeline with fresh state.
 		writer = iceberg.NewWriter(catalog, s3Client, stateStore, cfg.SlotName,
 			cfg.FlushRows, cfg.FlushInterval, logger,
-			iceberg.WithMutationMode(iceberg.MutationMode(cfg.MutationMode)))
+			iceberg.WithMutationMode(iceberg.MutationMode(cfg.MutationMode)),
+			iceberg.WithTargetFileSizeBytes(int64(cfg.TargetFileSizeMB)*1024*1024))
 		p = pipeline.New(pgConn, cfg.SlotName, pubName, startLSN, cfg.ExcludeTables,
 			logger, stateStore, tableFlushLSN, writer, cfg.FlushInterval, metaQuerier)
 
@@ -615,6 +644,64 @@ func runCleanup(cmd *cobra.Command, tables []string, dryRun, force bool) error {
 	}
 
 	logger.Info("cleanup complete")
+	return nil
+}
+
+// runMaintenance expires old Iceberg snapshots and optionally removes objects
+// that are no longer reachable from retained metadata. It should not be run
+// concurrently with a writer for the same table/prefix.
+func runMaintenance(cmd *cobra.Command, tables []string, retainLast int, includeOrphans bool, dryRun bool, force bool) error {
+	cfg := config.Load()
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		switch f.Name {
+		case "s3-bucket":
+			cfg.S3Bucket = f.Value.String()
+		case "s3-prefix":
+			cfg.S3Prefix = f.Value.String()
+		case "s3-endpoint":
+			cfg.S3Endpoint = f.Value.String()
+		case "s3-region":
+			cfg.S3Region = f.Value.String()
+		case "log-level":
+			cfg.LogLevel = f.Value.String()
+		}
+	})
+	if len(tables) == 0 {
+		return fmt.Errorf("--table schema.table is required")
+	}
+	if !dryRun && !force {
+		return fmt.Errorf("--force is required when --dry-run=false")
+	}
+	if includeOrphans && !dryRun {
+		return fmt.Errorf("orphan deletion currently supports dry-run only")
+	}
+	if cfg.S3Bucket == "" {
+		return fmt.Errorf("s3-bucket is required")
+	}
+	ctx := context.Background()
+	s3Client, err := storage.NewS3Client(ctx, cfg.S3Bucket, cfg.S3Region, cfg.S3Endpoint)
+	if err != nil {
+		return fmt.Errorf("create S3 client: %w", err)
+	}
+	catalog := iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
+	for _, tableRef := range tables {
+		parts := strings.Split(tableRef, ".")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("invalid table %q, want schema.table", tableRef)
+		}
+		plan, err := catalog.ExpireSnapshots(ctx, parts[0], parts[1], retainLast, dryRun)
+		if err != nil {
+			return fmt.Errorf("expire snapshots for %s: %w", tableRef, err)
+		}
+		fmt.Printf("%s: expired_snapshots=%d delete_objects=%d dry_run=%v\n", tableRef, plan.ExpiredSnapshots, len(plan.DeleteObjects), dryRun)
+		if includeOrphans {
+			orphanPlan, err := catalog.DeleteOrphanFiles(ctx, parts[0], parts[1], dryRun)
+			if err != nil {
+				return fmt.Errorf("delete orphans for %s: %w", tableRef, err)
+			}
+			fmt.Printf("%s: orphan_delete_objects=%d dry_run=%v\n", tableRef, len(orphanPlan.DeleteObjects), dryRun)
+		}
+	}
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,32 +9,34 @@ import (
 )
 
 type Config struct {
-	SourceURL     string
-	S3Bucket      string
-	S3Prefix      string
-	S3Endpoint    string
-	S3Region      string
-	StatePath     string
-	SlotName      string
-	FlushRows     int
-	FlushInterval time.Duration
-	IncludeTables []string
-	ExcludeTables []string
-	LogLevel      string
-	MutationMode  string // Iceberg row mutation strategy: "cow" or "mor"
-	QueryAddr     string // listen address for query server (e.g., ":5433")
+	SourceURL        string
+	S3Bucket         string
+	S3Prefix         string
+	S3Endpoint       string
+	S3Region         string
+	StatePath        string
+	SlotName         string
+	FlushRows        int
+	FlushInterval    time.Duration
+	TargetFileSizeMB int
+	IncludeTables    []string
+	ExcludeTables    []string
+	LogLevel         string
+	MutationMode     string // Iceberg row mutation strategy: "cow" or "mor"
+	QueryAddr        string // listen address for query server (e.g., ":5433")
 }
 
 func Default() *Config {
 	return &Config{
-		S3Prefix:      "streambed/",
-		S3Region:      "us-east-1",
-		StatePath:     defaultStatePath(),
-		SlotName:      "streambed",
-		FlushRows:     10000,
-		FlushInterval: 2 * time.Second,
-		LogLevel:      "INFO",
-		MutationMode:  "cow",
+		S3Prefix:         "streambed/",
+		S3Region:         "us-east-1",
+		StatePath:        defaultStatePath(),
+		SlotName:         "streambed",
+		FlushRows:        10000,
+		FlushInterval:    2 * time.Second,
+		TargetFileSizeMB: 128,
+		LogLevel:         "INFO",
+		MutationMode:     "cow",
 	}
 }
 
@@ -80,6 +82,11 @@ func Load() *Config {
 	if v := os.Getenv("STREAMBED_FLUSH_INTERVAL_SEC"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.FlushInterval = time.Duration(n) * time.Second
+		}
+	}
+	if v := os.Getenv("STREAMBED_TARGET_FILE_SIZE_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.TargetFileSizeMB = n
 		}
 	}
 	if v := os.Getenv("STREAMBED_INCLUDE_TABLES"); v != "" {
@@ -128,6 +135,9 @@ func (c *Config) Validate() error {
 	}
 	if c.FlushInterval <= 0 {
 		return fmt.Errorf("flush-interval must be positive")
+	}
+	if c.TargetFileSizeMB <= 0 {
+		return fmt.Errorf("target-file-size-mb must be positive")
 	}
 	if c.MutationMode != "cow" && c.MutationMode != "mor" {
 		return fmt.Errorf("mutation-mode must be one of: cow, mor")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,9 @@ func TestDefaults(t *testing.T) {
 	if cfg.FlushInterval != 2*time.Second {
 		t.Errorf("expected FlushInterval 2s, got %v", cfg.FlushInterval)
 	}
+	if cfg.TargetFileSizeMB != 128 {
+		t.Errorf("expected TargetFileSizeMB 128, got %d", cfg.TargetFileSizeMB)
+	}
 	if cfg.LogLevel != "INFO" {
 		t.Errorf("expected LogLevel 'INFO', got %q", cfg.LogLevel)
 	}
@@ -37,6 +40,7 @@ func TestLoadFromEnv(t *testing.T) {
 	os.Setenv("STREAMBED_S3_PREFIX", "data/")
 	os.Setenv("STREAMBED_FLUSH_ROWS", "5000")
 	os.Setenv("STREAMBED_FLUSH_INTERVAL_SEC", "10")
+	os.Setenv("STREAMBED_TARGET_FILE_SIZE_MB", "64")
 	os.Setenv("STREAMBED_INCLUDE_TABLES", "public.orders, public.users")
 	os.Setenv("STREAMBED_LOG_LEVEL", "debug")
 	os.Setenv("STREAMBED_MUTATION_MODE", "mor")
@@ -46,6 +50,7 @@ func TestLoadFromEnv(t *testing.T) {
 		os.Unsetenv("STREAMBED_S3_PREFIX")
 		os.Unsetenv("STREAMBED_FLUSH_ROWS")
 		os.Unsetenv("STREAMBED_FLUSH_INTERVAL_SEC")
+		os.Unsetenv("STREAMBED_TARGET_FILE_SIZE_MB")
 		os.Unsetenv("STREAMBED_INCLUDE_TABLES")
 		os.Unsetenv("STREAMBED_LOG_LEVEL")
 		os.Unsetenv("STREAMBED_MUTATION_MODE")
@@ -66,6 +71,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.FlushInterval != 10*time.Second {
 		t.Errorf("expected FlushInterval 10s, got %v", cfg.FlushInterval)
+	}
+	if cfg.TargetFileSizeMB != 64 {
+		t.Errorf("expected TargetFileSizeMB 64, got %d", cfg.TargetFileSizeMB)
 	}
 	if len(cfg.IncludeTables) != 2 || cfg.IncludeTables[0] != "public.orders" || cfg.IncludeTables[1] != "public.users" {
 		t.Errorf("expected IncludeTables [public.orders, public.users], got %v", cfg.IncludeTables)
@@ -98,11 +106,12 @@ func TestValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
-				SourceURL:     "postgres://localhost/test",
-				S3Bucket:      "bucket",
-				FlushRows:     10000,
-				FlushInterval: 30 * time.Second,
-				MutationMode:  "cow",
+				SourceURL:        "postgres://localhost/test",
+				S3Bucket:         "bucket",
+				FlushRows:        10000,
+				FlushInterval:    30 * time.Second,
+				TargetFileSizeMB: 128,
+				MutationMode:     "cow",
 			}
 			tt.modify(cfg)
 			err := cfg.Validate()

--- a/internal/iceberg/avro.go
+++ b/internal/iceberg/avro.go
@@ -63,6 +63,67 @@ func buildIcebergSchema(columns []ColumnDef) *ice.Schema {
 	return ice.NewSchema(0, fields...)
 }
 
+type dataManifestEntry struct {
+	FilePath string
+	File     DataFile
+}
+
+func buildIcebergDataFile(path string, rowCount, fileSize int64, lower, upper map[int][]byte, content ice.ManifestEntryContent) (ice.DataFile, error) {
+	dfBuilder, err := ice.NewDataFileBuilder(
+		*ice.UnpartitionedSpec,
+		content,
+		path,
+		ice.ParquetFile,
+		nil, nil, nil,
+		rowCount,
+		fileSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build data file: %w", err)
+	}
+	if len(lower) > 0 {
+		dfBuilder.LowerBoundValues(lower)
+	}
+	if len(upper) > 0 {
+		dfBuilder.UpperBoundValues(upper)
+	}
+	return dfBuilder.Build(), nil
+}
+
+// writeDataManifestAvro writes an Avro data manifest containing one or more
+// data files. Returns the raw Avro bytes and ManifestFile metadata object.
+func writeDataManifestAvro(
+	filename string,
+	schema *ice.Schema,
+	snapshotID int64,
+	seqNum int64,
+	files []dataManifestEntry,
+) ([]byte, ice.ManifestFile, error) {
+	entries := make([]ice.ManifestEntry, 0, len(files))
+	for _, f := range files {
+		df, err := buildIcebergDataFile(f.FilePath, f.File.RowCount, f.File.FileSize, f.File.LowerBounds, f.File.UpperBounds, ice.EntryContentData)
+		if err != nil {
+			return nil, nil, err
+		}
+		entry := ice.NewManifestEntryBuilder(
+			ice.EntryStatusADDED,
+			&snapshotID,
+			df,
+		).
+			SequenceNum(seqNum).
+			FileSequenceNum(seqNum).
+			Build()
+		entries = append(entries, entry)
+	}
+
+	buf := new(bytes.Buffer)
+	mf, err := ice.WriteManifest(filename, buf, 2, *ice.UnpartitionedSpec, schema, snapshotID, entries)
+	if err != nil {
+		return nil, nil, fmt.Errorf("write manifest: %w", err)
+	}
+	return buf.Bytes(), mf, nil
+}
+
 // writeManifestAvro writes an Avro manifest file using iceberg-go's WriteManifest.
 // Returns the raw Avro bytes and the ManifestFile metadata object.
 func writeManifestAvro(
@@ -74,39 +135,10 @@ func writeManifestAvro(
 	rowCount int64,
 	fileSize int64,
 ) ([]byte, ice.ManifestFile, error) {
-	// Build DataFile
-	dfBuilder, err := ice.NewDataFileBuilder(
-		*ice.UnpartitionedSpec,
-		ice.EntryContentData,
-		dataFilePath,
-		ice.ParquetFile,
-		nil, nil, nil,
-		rowCount,
-		fileSize,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("build data file: %w", err)
-	}
-	df := dfBuilder.Build()
-
-	// Build ManifestEntry
-	entry := ice.NewManifestEntryBuilder(
-		ice.EntryStatusADDED,
-		&snapshotID,
-		df,
-	).
-		SequenceNum(seqNum).
-		FileSequenceNum(seqNum).
-		Build()
-
-	// Write manifest
-	buf := new(bytes.Buffer)
-	mf, err := ice.WriteManifest(filename, buf, 2, *ice.UnpartitionedSpec, schema, snapshotID, []ice.ManifestEntry{entry})
-	if err != nil {
-		return nil, nil, fmt.Errorf("write manifest: %w", err)
-	}
-
-	return buf.Bytes(), mf, nil
+	return writeDataManifestAvro(filename, schema, snapshotID, seqNum, []dataManifestEntry{{
+		FilePath: dataFilePath,
+		File:     DataFile{RowCount: rowCount, FileSize: fileSize},
+	}})
 }
 
 // writeEqDeleteManifestAvro writes an Avro manifest file that tracks one

--- a/internal/iceberg/catalog.go
+++ b/internal/iceberg/catalog.go
@@ -25,9 +25,11 @@ type ColumnDef struct {
 
 // DataFile describes a Parquet data file to be committed.
 type DataFile struct {
-	Path     string // relative path under the table directory (e.g., "data/xxx.parquet")
-	RowCount int64
-	FileSize int64
+	Path        string // relative path under the table directory (e.g., "data/xxx.parquet") or full s3:// URI for existing files
+	RowCount    int64
+	FileSize    int64
+	LowerBounds map[int][]byte
+	UpperBounds map[int][]byte
 }
 
 // EqDeleteFile describes a Parquet equality-delete file to be committed.
@@ -364,9 +366,10 @@ func (c *Catalog) EvolveSchema(
 	return fieldIDs, nil
 }
 
-// GetDataFilePaths returns the S3 paths of all data files in the current
-// snapshot for the given table. Returns nil if the table has no snapshots.
-func (c *Catalog) GetDataFilePaths(ctx context.Context, schema, table string) ([]string, error) {
+// GetActiveDataFiles returns all active data files in the current snapshot.
+// Bounds are populated when present in the Iceberg manifest. Returns nil if
+// the table has no current snapshot.
+func (c *Catalog) GetActiveDataFiles(ctx context.Context, schema, table string) ([]DataFile, error) {
 	basePath := c.tablePath(schema, table)
 
 	hintKey := path.Join(basePath, "metadata", "version-hint.text")
@@ -393,7 +396,6 @@ func (c *Catalog) GetDataFilePaths(ctx context.Context, schema, table string) ([
 		return nil, nil
 	}
 
-	// Find manifest list for the current snapshot.
 	var manifestListURI string
 	for _, snap := range metadata.Snapshots {
 		if snap.SnapshotID == metadata.CurrentSnapshotID {
@@ -414,9 +416,8 @@ func (c *Catalog) GetDataFilePaths(ctx context.Context, schema, table string) ([
 		return nil, fmt.Errorf("parse manifest list: %w", err)
 	}
 
-	var paths []string
+	var files []DataFile
 	for _, mf := range manifests {
-		// Only read data manifests, skip delete manifests.
 		if mf.ManifestContent() != ice.ManifestContentData {
 			continue
 		}
@@ -429,10 +430,45 @@ func (c *Catalog) GetDataFilePaths(ctx context.Context, schema, table string) ([
 			return nil, fmt.Errorf("parse manifest: %w", err)
 		}
 		for _, entry := range entries {
-			paths = append(paths, entry.DataFile().FilePath())
+			if entry.Status() == ice.EntryStatusDELETED {
+				continue
+			}
+			df := entry.DataFile()
+			files = append(files, DataFile{
+				Path:        df.FilePath(),
+				RowCount:    df.Count(),
+				FileSize:    df.FileSizeBytes(),
+				LowerBounds: cloneBounds(df.LowerBoundValues()),
+				UpperBounds: cloneBounds(df.UpperBoundValues()),
+			})
 		}
 	}
+	return files, nil
+}
+
+// GetDataFilePaths returns the S3 paths of all data files in the current
+// snapshot for the given table. Returns nil if the table has no snapshots.
+func (c *Catalog) GetDataFilePaths(ctx context.Context, schema, table string) ([]string, error) {
+	files, err := c.GetActiveDataFiles(ctx, schema, table)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
 	return paths, nil
+}
+
+func cloneBounds(in map[int][]byte) map[int][]byte {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[int][]byte, len(in))
+	for k, v := range in {
+		out[k] = append([]byte(nil), v...)
+	}
+	return out
 }
 
 // ValidateMutationMode fails fast when COW is selected but an existing table
@@ -521,30 +557,12 @@ func (c *Catalog) HasEqualityDeleteFiles(ctx context.Context, schema, table stri
 // This is a thin wrapper around CommitChangeset for append-only callers
 // (see resync and initial backfill paths).
 func (c *Catalog) CommitSnapshot(ctx context.Context, schema, table string, dataFile DataFile, flushLSN string) error {
-	return c.CommitChangeset(ctx, schema, table, &dataFile, nil, false, flushLSN)
+	return c.CommitChangesetFiles(ctx, schema, table, []DataFile{dataFile}, nil, nil, false, flushLSN)
 }
 
 // CommitChangeset atomically adds one snapshot that may contain a data
-// file and/or an equality-delete file.
-//
-// When replace is false (append mode), previous manifest files are
-// carried forward so all historical data files remain visible. When
-// replace is true (overwrite / COW mode), previous manifests are NOT
-// carried forward — only the files in this commit are visible. This is
-// used for copy-on-write deletes where the caller has already merged
-// existing data with pending changes.
-//
-// When replace is true, dataFile may be nil (meaning the table is now
-// empty after all rows were deleted).
-//
-// Steps (in order):
-//  1. Read version-hint.text → current version N
-//  2. Read v<N>.metadata.json
-//  3. Write data-manifest (Avro) if dataFile != nil
-//  4. Write eq-delete-manifest (Avro) if eqDel != nil
-//  5. Write manifest list (Avro) referencing new manifests (+ prior if !replace)
-//  6. Write v<N+1>.metadata.json with new snapshot
-//  7. Write version-hint.text with N+1 (THE LAST STEP)
+// file and/or an equality-delete file. Kept as a compatibility wrapper for
+// single-file callers.
 func (c *Catalog) CommitChangeset(
 	ctx context.Context,
 	schema, table string,
@@ -553,19 +571,39 @@ func (c *Catalog) CommitChangeset(
 	replace bool,
 	flushLSN string,
 ) error {
-	if dataFile == nil && eqDel == nil && !replace {
-		return fmt.Errorf("commit changeset: both data and delete are nil")
+	var dataFiles []DataFile
+	if dataFile != nil {
+		dataFiles = []DataFile{*dataFile}
 	}
+	var deleteFiles []EqDeleteFile
+	if eqDel != nil {
+		deleteFiles = []EqDeleteFile{*eqDel}
+	}
+	return c.CommitChangesetFiles(ctx, schema, table, dataFiles, deleteFiles, nil, replace, flushLSN)
+}
 
-	// COW replacement with no rows means the table is logically empty. Do not
-	// publish a zero-row data manifest: iceberg-go rejects true 0-row entries,
-	// and advertising a fake row count can make readers retain a ghost row.
-	if replace && (dataFile == nil || dataFile.RowCount == 0) {
+// CommitChangesetFiles commits a snapshot with multiple data/delete files.
+// In replace mode, carriedDataFiles are active existing data files that should
+// remain visible without being rewritten; dataFiles are newly written
+// replacements. In append mode, carriedDataFiles must be nil because prior
+// manifests are carried forward automatically.
+func (c *Catalog) CommitChangesetFiles(
+	ctx context.Context,
+	schema, table string,
+	dataFiles []DataFile,
+	eqDeleteFiles []EqDeleteFile,
+	carriedDataFiles []DataFile,
+	replace bool,
+	flushLSN string,
+) error {
+	if len(dataFiles) == 0 && len(eqDeleteFiles) == 0 && len(carriedDataFiles) == 0 && !replace {
+		return fmt.Errorf("commit changeset: no data or delete files")
+	}
+	if replace && len(dataFiles) == 0 && len(carriedDataFiles) == 0 {
 		return c.commitEmptyTable(ctx, schema, table, flushLSN)
 	}
-	basePath := c.tablePath(schema, table)
 
-	// 1. Read current version
+	basePath := c.tablePath(schema, table)
 	hintKey := path.Join(basePath, "metadata", "version-hint.text")
 	hintData, err := c.storage.GetObject(ctx, hintKey)
 	if err != nil {
@@ -576,65 +614,53 @@ func (c *Catalog) CommitChangeset(
 		return fmt.Errorf("parse version hint %q: %w", hintData, err)
 	}
 
-	// 2. Read current metadata
 	currentMetaKey := path.Join(basePath, "metadata", fmt.Sprintf("v%d.metadata.json", currentVersion))
 	metaData, err := c.storage.GetObject(ctx, currentMetaKey)
 	if err != nil {
 		return fmt.Errorf("read metadata v%d: %w", currentVersion, err)
 	}
-
 	var metadata tableMetadata
 	if err := json.Unmarshal(metaData, &metadata); err != nil {
 		return fmt.Errorf("parse metadata: %w", err)
 	}
 
-	// Snapshot IDs must be unique even when multiple flushes commit within the
-	// same millisecond (common in tests and local object stores). Timestamps in
-	// metadata remain milliseconds; the ID itself has no time-unit semantics.
 	snapID := time.Now().UnixNano()
 	seqNum := metadata.LastSequenceNumber + 1
-
-	// Build iceberg-go schema from metadata
 	iceSchema := schemaFromMetadata(metadata)
-
-	// 3/4. Write one manifest per content type (data vs delete).
 	var manifestFiles []ice.ManifestFile
 
-	if dataFile != nil {
-		dataFilePath := fmt.Sprintf("s3://%s/%s/%s", c.bucket, basePath, dataFile.Path)
+	allDataFiles := append([]DataFile{}, carriedDataFiles...)
+	allDataFiles = append(allDataFiles, dataFiles...)
+	if len(allDataFiles) > 0 {
 		manifestUUID := uuid.New().String()
 		manifestFilename := fmt.Sprintf("%s-m0.avro", manifestUUID)
 		manifestKey := path.Join(basePath, "metadata", manifestFilename)
 		manifestS3Path := fmt.Sprintf("s3://%s/%s", c.bucket, manifestKey)
-
-		// iceberg-go requires record_count > 0 in manifest entries. When the
-		// writer produces a 0-row Parquet file (all rows deleted via COW),
-		// advertise 1 row so the manifest passes validation. DuckDB reads the
-		// actual row count from the Parquet footer, so this is harmless.
-		manifestRowCount := dataFile.RowCount
-		if manifestRowCount == 0 {
-			manifestRowCount = 1
+		entries := make([]dataManifestEntry, 0, len(allDataFiles))
+		for _, f := range allDataFiles {
+			if f.RowCount <= 0 {
+				continue
+			}
+			entries = append(entries, dataManifestEntry{FilePath: c.dataFileURI(basePath, f), File: f})
 		}
-		manifestBytes, mf, err := writeManifestAvro(
-			manifestS3Path, iceSchema, snapID, seqNum,
-			dataFilePath, manifestRowCount, dataFile.FileSize,
-		)
-		if err != nil {
-			return fmt.Errorf("write manifest avro: %w", err)
+		if len(entries) > 0 {
+			manifestBytes, mf, err := writeDataManifestAvro(manifestS3Path, iceSchema, snapID, seqNum, entries)
+			if err != nil {
+				return fmt.Errorf("write data manifest avro: %w", err)
+			}
+			if err := c.storage.PutObject(ctx, manifestKey, manifestBytes, "application/octet-stream"); err != nil {
+				return err
+			}
+			manifestFiles = append(manifestFiles, mf)
 		}
-		if err := c.storage.PutObject(ctx, manifestKey, manifestBytes, "application/octet-stream"); err != nil {
-			return err
-		}
-		manifestFiles = append(manifestFiles, mf)
 	}
 
-	if eqDel != nil {
-		delFilePath := fmt.Sprintf("s3://%s/%s/%s", c.bucket, basePath, eqDel.Path)
+	for _, eqDel := range eqDeleteFiles {
+		delFilePath := c.dataFileURI(basePath, DataFile{Path: eqDel.Path})
 		manifestUUID := uuid.New().String()
 		manifestFilename := fmt.Sprintf("%s-m0-del.avro", manifestUUID)
 		manifestKey := path.Join(basePath, "metadata", manifestFilename)
 		manifestS3Path := fmt.Sprintf("s3://%s/%s", c.bucket, manifestKey)
-
 		manifestBytes, mf, err := writeEqDeleteManifestAvro(
 			manifestS3Path, iceSchema, snapID, seqNum,
 			delFilePath, eqDel.RowCount, eqDel.FileSize, eqDel.EqualityFieldIDs,
@@ -648,7 +674,9 @@ func (c *Catalog) CommitChangeset(
 		manifestFiles = append(manifestFiles, mf)
 	}
 
-	// Carry forward previous manifest files (append mode only).
+	// Carry forward previous manifest files in append mode only. Replace mode
+	// publishes a new active data manifest containing carried + replacement
+	// files, so old manifests are intentionally not active.
 	if !replace && metadata.CurrentSnapshotID > 0 {
 		for _, snap := range metadata.Snapshots {
 			if snap.SnapshotID == metadata.CurrentSnapshotID {
@@ -666,51 +694,47 @@ func (c *Catalog) CommitChangeset(
 	if metadata.CurrentSnapshotID > 0 {
 		parentSnapID = &metadata.CurrentSnapshotID
 	}
-
 	manifestListBytes, err := writeManifestListAvro(snapID, seqNum, parentSnapID, manifestFiles)
 	if err != nil {
 		return fmt.Errorf("write manifest list avro: %w", err)
 	}
-
 	snapUUID := uuid.New().String()
-	manifestListKey := path.Join(basePath, "metadata",
-		fmt.Sprintf("snap-%d-%s.avro", snapID, snapUUID))
+	manifestListKey := path.Join(basePath, "metadata", fmt.Sprintf("snap-%d-%s.avro", snapID, snapUUID))
 	if err := c.storage.PutObject(ctx, manifestListKey, manifestListBytes, "application/octet-stream"); err != nil {
 		return err
 	}
 
-	// 5. Write new metadata
 	newVersion := currentVersion + 1
 	metadata.LastSequenceNumber = seqNum
 	metadata.LastUpdatedMS = time.Now().UnixMilli()
 	metadata.CurrentSnapshotID = snapID
 
-	// Build summary. Operation is "append" for data-only, "delete" for
-	// delete-only, and "overwrite" for mixed (the canonical Iceberg
-	// operation name for a commit that both adds and removes rows).
-	summary := map[string]string{}
-	var addedRows int64
-	var addedData int64
-	if dataFile != nil {
-		addedData = 1
-		addedRows = dataFile.RowCount
-		summary["added-data-files"] = "1"
-		summary["added-records"] = strconv.FormatInt(dataFile.RowCount, 10)
+	var addedRows, totalRows int64
+	for _, f := range dataFiles {
+		addedRows += f.RowCount
 	}
-	var addedDeletes int64
-	var addedDeleteRows int64
-	if eqDel != nil {
-		addedDeletes = 1
-		addedDeleteRows = eqDel.RowCount
-		summary["added-delete-files"] = "1"
-		summary["added-equality-deletes"] = strconv.FormatInt(eqDel.RowCount, 10)
+	for _, f := range allDataFiles {
+		totalRows += f.RowCount
+	}
+	summary := map[string]string{}
+	if len(dataFiles) > 0 {
+		summary["added-data-files"] = strconv.Itoa(len(dataFiles))
+		summary["added-records"] = strconv.FormatInt(addedRows, 10)
+	}
+	var deleteRows int64
+	for _, f := range eqDeleteFiles {
+		deleteRows += f.RowCount
+	}
+	if len(eqDeleteFiles) > 0 {
+		summary["added-delete-files"] = strconv.Itoa(len(eqDeleteFiles))
+		summary["added-equality-deletes"] = strconv.FormatInt(deleteRows, 10)
 	}
 	switch {
 	case replace:
 		summary["operation"] = "overwrite"
-	case addedData > 0 && addedDeletes > 0:
+	case len(dataFiles) > 0 && len(eqDeleteFiles) > 0:
 		summary["operation"] = "overwrite"
-	case addedDeletes > 0:
+	case len(eqDeleteFiles) > 0:
 		summary["operation"] = "delete"
 	default:
 		summary["operation"] = "append"
@@ -719,53 +743,35 @@ func (c *Catalog) CommitChangeset(
 		summary["streambed.last_flush_lsn"] = flushLSN
 	}
 	if replace {
-		// Overwrite: total-records is exactly the replacement file's rows.
-		summary["total-records"] = strconv.FormatInt(addedRows, 10)
-	} else if eqDel == nil && !hasEqualityDeletes(metadata.Snapshots) {
-		// Continue from the current snapshot's exact total. Summing historical
-		// added-records is wrong after an overwrite because replaced rows are
-		// still present in snapshot history.
+		summary["total-records"] = strconv.FormatInt(totalRows, 10)
+	} else if len(eqDeleteFiles) == 0 && !hasEqualityDeletes(metadata.Snapshots) {
 		if currentTotal, exact := currentSnapshotTotalRecords(metadata); exact {
 			summary["total-records"] = strconv.FormatInt(currentTotal+addedRows, 10)
 		}
 	}
-	_ = addedDeleteRows
 
-	newSnapshot := snapshot{
-		SnapshotID:     snapID,
-		SequenceNumber: seqNum,
-		TimestampMS:    time.Now().UnixMilli(),
-		ManifestList:   fmt.Sprintf("s3://%s/%s", c.bucket, manifestListKey),
-		Summary:        summary,
-	}
+	newSnapshot := snapshot{SnapshotID: snapID, SequenceNumber: seqNum, TimestampMS: time.Now().UnixMilli(), ManifestList: fmt.Sprintf("s3://%s/%s", c.bucket, manifestListKey), Summary: summary}
 	metadata.Snapshots = append(metadata.Snapshots, newSnapshot)
-	metadata.SnapshotLog = append(metadata.SnapshotLog, snapshotLogEntry{
-		TimestampMS: newSnapshot.TimestampMS,
-		SnapshotID:  snapID,
-	})
-	metadata.Refs = map[string]interface{}{
-		"main": map[string]interface{}{
-			"snapshot-id": snapID,
-			"type":        "branch",
-		},
-	}
-	metadata.MetadataLog = append(metadata.MetadataLog, metadataLogEntry{
-		TimestampMS:  metadata.LastUpdatedMS,
-		MetadataFile: fmt.Sprintf("s3://%s/%s", c.bucket, currentMetaKey),
-	})
+	metadata.SnapshotLog = append(metadata.SnapshotLog, snapshotLogEntry{TimestampMS: newSnapshot.TimestampMS, SnapshotID: snapID})
+	metadata.Refs = map[string]interface{}{"main": map[string]interface{}{"snapshot-id": snapID, "type": "branch"}}
+	metadata.MetadataLog = append(metadata.MetadataLog, metadataLogEntry{TimestampMS: metadata.LastUpdatedMS, MetadataFile: fmt.Sprintf("s3://%s/%s", c.bucket, currentMetaKey)})
 
 	newMetadataJSON, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal new metadata: %w", err)
 	}
-
 	newMetaKey := path.Join(basePath, "metadata", fmt.Sprintf("v%d.metadata.json", newVersion))
 	if err := c.storage.PutObject(ctx, newMetaKey, newMetadataJSON, "application/json"); err != nil {
 		return err
 	}
-
-	// 6. Update version-hint.text — THE LAST STEP
 	return c.storage.PutObject(ctx, hintKey, []byte(strconv.Itoa(newVersion)), "text/plain")
+}
+
+func (c *Catalog) dataFileURI(basePath string, f DataFile) string {
+	if strings.HasPrefix(f.Path, "s3://") {
+		return f.Path
+	}
+	return fmt.Sprintf("s3://%s/%s/%s", c.bucket, basePath, f.Path)
 }
 
 // commitEmptyTable bumps the metadata version with current-snapshot-id = -1,

--- a/internal/iceberg/cow_layout_test.go
+++ b/internal/iceberg/cow_layout_test.go
@@ -1,0 +1,142 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	pqbuilder "github.com/viggy28/streambed/internal/parquet"
+	"github.com/viggy28/streambed/internal/storage"
+)
+
+func TestTargetSizeMultiFileOutput(t *testing.T) {
+	w, _ := testWriter(t)
+	w.targetFileSizeBytes = 700
+	ctx := context.Background()
+	for i := 1; i <= 80; i++ {
+		if _, err := w.HandleEvent(ctx, insertEvent("public", "mf", pglogrepl.LSN(i), strconv.Itoa(i), fmt.Sprintf("name-%04d-xxxxxxxxxxxxxxxxxxxxxxxx", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	files, err := w.catalog.GetActiveDataFiles(ctx, "public", "mf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) < 2 {
+		t.Fatalf("active data files=%d, want multi-file output", len(files))
+	}
+	var rows int64
+	for _, f := range files {
+		rows += f.RowCount
+		if len(f.LowerBounds) == 0 || len(f.UpperBounds) == 0 {
+			t.Fatalf("file %s missing key bounds", f.Path)
+		}
+	}
+	if rows != 80 {
+		t.Fatalf("rows=%d, want 80", rows)
+	}
+}
+
+func TestCOWFileLevelRewritePrunesUnaffectedFiles(t *testing.T) {
+	ctx := context.Background()
+	mem := storage.NewMemS3Client("test-bucket")
+	counting := &countingStorage{inner: mem}
+	catalog := NewCatalog(counting, "test-bucket", "test-prefix")
+	store := testStateStore(t)
+	w := NewWriter(catalog, counting, store, "test_slot", 10000, 2*time.Second, testLogger(), WithTargetFileSizeBytes(700))
+
+	for i := 1; i <= 80; i++ {
+		if _, err := w.HandleEvent(ctx, insertEvent("public", "acct", pglogrepl.LSN(i), strconv.Itoa(i), fmt.Sprintf("name-%04d-xxxxxxxxxxxxxxxxxxxxxxxx", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	filesBefore, err := catalog.GetActiveDataFiles(ctx, "public", "acct")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filesBefore) < 2 {
+		t.Fatalf("setup active files=%d, want >=2", len(filesBefore))
+	}
+	counting.parquetGets = 0
+	counting.parquetGetBytes = 0
+	if _, err := w.HandleEvent(ctx, updateEvent("public", "acct", 1000, "2", "2", "updated")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if counting.parquetGets >= len(filesBefore) {
+		t.Fatalf("COW read %d parquet files, want fewer than all %d", counting.parquetGets, len(filesBefore))
+	}
+	paths, err := catalog.GetDataFilePaths(ctx, "public", "acct")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cols := []pqbuilder.ColumnDef{{Name: "id", OID: 23, FieldID: 1}, {Name: "name", OID: 25, FieldID: 2}}
+	var total int
+	seenUpdated := false
+	for _, p := range paths {
+		data, err := mem.GetObject(ctx, s3KeyFromURI(p))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows, err := pqbuilder.ReadRows(data, cols)
+		if err != nil {
+			t.Fatal(err)
+		}
+		total += len(rows)
+		for _, row := range rows {
+			if string(row[0].Data) == "2" && string(row[1].Data) == "updated" {
+				seenUpdated = true
+			}
+		}
+	}
+	if total != 80 || !seenUpdated {
+		t.Fatalf("total=%d updated=%v", total, seenUpdated)
+	}
+}
+
+func TestSnapshotExpirationAndOrphanDryRun(t *testing.T) {
+	w, mem := testWriter(t)
+	ctx := context.Background()
+	for i := 1; i <= 3; i++ {
+		if _, err := w.HandleEvent(ctx, insertEvent("public", "gc", pglogrepl.LSN(i), strconv.Itoa(i), "live")); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.FlushAll(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plan, err := w.catalog.ExpireSnapshots(ctx, "public", "gc", 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.ExpiredSnapshots == 0 || len(plan.DeleteObjects) == 0 {
+		t.Fatalf("dry-run plan did not find expired objects: %+v", plan)
+	}
+	before, _ := mem.ListPrefix(ctx, "test-prefix/public/gc")
+	plan, err = w.catalog.ExpireSnapshots(ctx, "public", "gc", 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, _ := mem.ListPrefix(ctx, "test-prefix/public/gc")
+	if len(after) >= len(before) {
+		t.Fatalf("expiration did not delete objects: before=%d after=%d plan=%+v", len(before), len(after), plan)
+	}
+	paths, err := w.catalog.GetDataFilePaths(ctx, "public", "gc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("current snapshot data file was deleted")
+	}
+}

--- a/internal/iceberg/cow_prune.go
+++ b/internal/iceberg/cow_prune.go
@@ -1,0 +1,179 @@
+package iceberg
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strconv"
+
+	pqbuilder "github.com/viggy28/streambed/internal/parquet"
+)
+
+func selectCOWFiles(files []DataFile, buf *tableBuffer, cols []pqbuilder.ColumnDef) (candidates, carried []DataFile, pruned bool) {
+	if len(files) == 0 || len(buf.Deletes) == 0 || len(buf.KeyColumns) == 0 {
+		return files, nil, false
+	}
+	fieldIDs := make([]int, len(buf.KeyColumns))
+	keyOIDs := make([]uint32, len(buf.KeyColumns))
+	for i, idx := range buf.KeyColumns {
+		if idx < 0 || idx >= len(buf.Columns) {
+			return files, nil, false
+		}
+		col := buf.Columns[idx]
+		id := buf.fieldIDs[col.Name]
+		if id <= 0 {
+			return files, nil, false
+		}
+		fieldIDs[i] = id
+		keyOIDs[i] = col.OID
+	}
+	encodedDeletes := make([][][]byte, 0, len(buf.Deletes))
+	for _, del := range dedupValueRows(buf.Deletes) {
+		if len(del) != len(fieldIDs) {
+			return files, nil, false
+		}
+		enc := make([][]byte, len(del))
+		for i, v := range del {
+			b, ok := encodeBoundValue(keyOIDs[i], v)
+			if !ok {
+				return files, nil, false
+			}
+			enc[i] = b
+		}
+		encodedDeletes = append(encodedDeletes, enc)
+	}
+	for _, f := range files {
+		if !hasRequiredBounds(f, fieldIDs) {
+			return files, nil, false
+		}
+		if fileMayContainAnyKey(f, fieldIDs, keyOIDs, encodedDeletes) {
+			candidates = append(candidates, f)
+		} else {
+			carried = append(carried, f)
+		}
+	}
+	return candidates, carried, len(carried) > 0
+}
+
+func hasRequiredBounds(f DataFile, fieldIDs []int) bool {
+	for _, id := range fieldIDs {
+		if _, ok := f.LowerBounds[id]; !ok {
+			return false
+		}
+		if _, ok := f.UpperBounds[id]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func fileMayContainAnyKey(f DataFile, fieldIDs []int, oids []uint32, encodedKeys [][][]byte) bool {
+	for _, key := range encodedKeys {
+		mayContain := true
+		for i, id := range fieldIDs {
+			lo, hi := f.LowerBounds[id], f.UpperBounds[id]
+			if compareEncodedBound(oids[i], key[i], lo) < 0 || compareEncodedBound(oids[i], key[i], hi) > 0 {
+				mayContain = false
+				break
+			}
+		}
+		if mayContain {
+			return true
+		}
+	}
+	return false
+}
+
+func compareEncodedBound(oid uint32, a, b []byte) int {
+	switch oid {
+	case 21, 23:
+		if len(a) >= 4 && len(b) >= 4 {
+			av := int32(binary.LittleEndian.Uint32(a))
+			bv := int32(binary.LittleEndian.Uint32(b))
+			switch {
+			case av < bv:
+				return -1
+			case av > bv:
+				return 1
+			default:
+				return 0
+			}
+		}
+	case 20:
+		if len(a) >= 8 && len(b) >= 8 {
+			av := int64(binary.LittleEndian.Uint64(a))
+			bv := int64(binary.LittleEndian.Uint64(b))
+			switch {
+			case av < bv:
+				return -1
+			case av > bv:
+				return 1
+			default:
+				return 0
+			}
+		}
+	}
+	return bytes.Compare(a, b)
+}
+
+func computeKeyBounds(buf *tableBuffer, rows [][]pqbuilder.Value) (map[int][]byte, map[int][]byte) {
+	if len(buf.KeyColumns) == 0 || len(rows) == 0 {
+		return nil, nil
+	}
+	lower := make(map[int][]byte)
+	upper := make(map[int][]byte)
+	for _, row := range rows {
+		for _, idx := range buf.KeyColumns {
+			if idx < 0 || idx >= len(buf.Columns) || idx >= len(row) {
+				return nil, nil
+			}
+			col := buf.Columns[idx]
+			id := buf.fieldIDs[col.Name]
+			if id <= 0 {
+				return nil, nil
+			}
+			b, ok := encodeBoundValue(col.OID, row[idx])
+			if !ok {
+				return nil, nil
+			}
+			if cur, ok := lower[id]; !ok || compareEncodedBound(col.OID, b, cur) < 0 {
+				lower[id] = append([]byte(nil), b...)
+			}
+			if cur, ok := upper[id]; !ok || compareEncodedBound(col.OID, b, cur) > 0 {
+				upper[id] = append([]byte(nil), b...)
+			}
+		}
+	}
+	return lower, upper
+}
+
+func encodeBoundValue(oid uint32, v pqbuilder.Value) ([]byte, bool) {
+	if v.IsNull {
+		return nil, false
+	}
+	s := string(v.Data)
+	switch oid {
+	case 21, 23:
+		n, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return nil, false
+		}
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], uint32(int32(n)))
+		return b[:], true
+	case 20:
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], uint64(n))
+		return b[:], true
+	case 16, 17, 700, 701, 1082, 1114, 1184, 2950:
+		// These Iceberg types need type-specific binary bound encodings. Until
+		// those are implemented, omit bounds so COW pruning falls back safely.
+		return nil, false
+	default:
+		// PgOIDToIcebergType maps all other OIDs to Iceberg string today.
+		return []byte(s), true
+	}
+}

--- a/internal/iceberg/maintenance.go
+++ b/internal/iceberg/maintenance.go
@@ -1,0 +1,211 @@
+package iceberg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	ice "github.com/apache/iceberg-go"
+)
+
+type MaintenancePlan struct {
+	Table            string
+	ExpiredSnapshots int
+	DeleteObjects    []string
+}
+
+// ExpireSnapshots keeps the current snapshot plus retainLast most recent older
+// snapshots and deletes objects that are reachable only from expired snapshots.
+// It is intentionally conservative: it never deletes objects reachable from any
+// retained snapshot and does not attempt arbitrary orphan deletion.
+func (c *Catalog) ExpireSnapshots(ctx context.Context, schema, table string, retainLast int, dryRun bool) (MaintenancePlan, error) {
+	if retainLast < 0 {
+		retainLast = 0
+	}
+	meta, version, metaKey, err := c.readCurrentMetadata(ctx, schema, table)
+	if err != nil {
+		return MaintenancePlan{}, err
+	}
+	plan := MaintenancePlan{Table: schema + "." + table}
+	if len(meta.Snapshots) == 0 {
+		return plan, nil
+	}
+
+	retainedIDs := map[int64]bool{}
+	if meta.CurrentSnapshotID > 0 {
+		retainedIDs[meta.CurrentSnapshotID] = true
+	}
+	ordered := append([]snapshot(nil), meta.Snapshots...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].TimestampMS > ordered[j].TimestampMS })
+	for _, s := range ordered {
+		if len(retainedIDs) >= retainLast+1 {
+			break
+		}
+		retainedIDs[s.SnapshotID] = true
+	}
+
+	retainedReachable := map[string]bool{}
+	expiredReachable := map[string]bool{}
+	for _, s := range meta.Snapshots {
+		target := expiredReachable
+		if retainedIDs[s.SnapshotID] {
+			target = retainedReachable
+		}
+		if err := c.collectSnapshotObjects(ctx, s, target); err != nil {
+			return plan, err
+		}
+	}
+	basePath := c.tablePath(schema, table)
+	retainedReachable[path.Join(basePath, "metadata", "version-hint.text")] = true
+	retainedReachable[metaKey] = true
+	for _, ml := range meta.MetadataLog {
+		retainedReachable[s3KeyFromURI(ml.MetadataFile)] = true
+	}
+
+	for key := range expiredReachable {
+		if !retainedReachable[key] {
+			plan.DeleteObjects = append(plan.DeleteObjects, key)
+		}
+	}
+	sort.Strings(plan.DeleteObjects)
+
+	var kept []snapshot
+	for _, s := range meta.Snapshots {
+		if retainedIDs[s.SnapshotID] {
+			kept = append(kept, s)
+		} else {
+			plan.ExpiredSnapshots++
+		}
+	}
+	if dryRun || plan.ExpiredSnapshots == 0 {
+		return plan, nil
+	}
+	meta.Snapshots = kept
+	var keptLog []snapshotLogEntry
+	for _, e := range meta.SnapshotLog {
+		if retainedIDs[e.SnapshotID] {
+			keptLog = append(keptLog, e)
+		}
+	}
+	meta.SnapshotLog = keptLog
+	meta.LastUpdatedMS = time.Now().UnixMilli()
+	newVersion := version + 1
+	newMetaKey := path.Join(basePath, "metadata", fmt.Sprintf("v%d.metadata.json", newVersion))
+	meta.MetadataLog = append(meta.MetadataLog, metadataLogEntry{TimestampMS: meta.LastUpdatedMS, MetadataFile: fmt.Sprintf("s3://%s/%s", c.bucket, metaKey)})
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return plan, err
+	}
+	if err := c.storage.PutObject(ctx, newMetaKey, data, "application/json"); err != nil {
+		return plan, err
+	}
+	if err := c.storage.PutObject(ctx, path.Join(basePath, "metadata", "version-hint.text"), []byte(strconv.Itoa(newVersion)), "text/plain"); err != nil {
+		return plan, err
+	}
+	if len(plan.DeleteObjects) > 0 {
+		if err := c.storage.DeleteObjects(ctx, plan.DeleteObjects); err != nil {
+			return plan, err
+		}
+	}
+	return plan, nil
+}
+
+// DeleteOrphanFiles deletes objects under a table prefix that are not reachable
+// from the current metadata file and current snapshot. It defaults to dry-run at
+// the CLI layer; callers should avoid running it concurrently with sync.
+func (c *Catalog) DeleteOrphanFiles(ctx context.Context, schema, table string, dryRun bool) (MaintenancePlan, error) {
+	if !dryRun {
+		return MaintenancePlan{}, fmt.Errorf("orphan deletion requires object age/locking support; run dry-run only")
+	}
+	meta, _, metaKey, err := c.readCurrentMetadata(ctx, schema, table)
+	if err != nil {
+		return MaintenancePlan{}, err
+	}
+	basePath := c.tablePath(schema, table)
+	plan := MaintenancePlan{Table: schema + "." + table}
+	reachable := map[string]bool{
+		path.Join(basePath, "metadata", "version-hint.text"): true,
+		metaKey: true,
+	}
+	for _, ml := range meta.MetadataLog {
+		reachable[s3KeyFromURI(ml.MetadataFile)] = true
+	}
+	for _, s := range meta.Snapshots {
+		if err := c.collectSnapshotObjects(ctx, s, reachable); err != nil {
+			return plan, err
+		}
+	}
+	keys, err := c.storage.ListPrefix(ctx, basePath)
+	if err != nil {
+		return plan, err
+	}
+	for _, key := range keys {
+		clean := strings.TrimPrefix(path.Clean(key), "/")
+		if !reachable[clean] {
+			plan.DeleteObjects = append(plan.DeleteObjects, clean)
+		}
+	}
+	sort.Strings(plan.DeleteObjects)
+	return plan, nil
+}
+
+func (c *Catalog) readCurrentMetadata(ctx context.Context, schema, table string) (tableMetadata, int, string, error) {
+	basePath := c.tablePath(schema, table)
+	hintKey := path.Join(basePath, "metadata", "version-hint.text")
+	hintData, err := c.storage.GetObject(ctx, hintKey)
+	if err != nil {
+		return tableMetadata{}, 0, "", fmt.Errorf("read version-hint: %w", err)
+	}
+	version, err := strconv.Atoi(string(hintData))
+	if err != nil {
+		return tableMetadata{}, 0, "", fmt.Errorf("parse version hint: %w", err)
+	}
+	metaKey := path.Join(basePath, "metadata", fmt.Sprintf("v%d.metadata.json", version))
+	metaData, err := c.storage.GetObject(ctx, metaKey)
+	if err != nil {
+		return tableMetadata{}, 0, "", fmt.Errorf("read metadata: %w", err)
+	}
+	var meta tableMetadata
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		return tableMetadata{}, 0, "", fmt.Errorf("parse metadata: %w", err)
+	}
+	return meta, version, metaKey, nil
+}
+
+func (c *Catalog) collectSnapshotObjects(ctx context.Context, s snapshot, out map[string]bool) error {
+	if s.ManifestList == "" {
+		return nil
+	}
+	manifestListKey := s3KeyFromURI(s.ManifestList)
+	out[manifestListKey] = true
+	manifestListData, err := c.storage.GetObject(ctx, manifestListKey)
+	if err != nil {
+		return err
+	}
+	manifests, err := readManifestListAvro(manifestListData)
+	if err != nil {
+		return err
+	}
+	for _, mf := range manifests {
+		manifestKey := s3KeyFromURI(mf.FilePath())
+		out[manifestKey] = true
+		mfData, err := c.storage.GetObject(ctx, manifestKey)
+		if err != nil {
+			return err
+		}
+		entries, err := ice.ReadManifest(mf, bytes.NewReader(mfData), true)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			out[s3KeyFromURI(e.DataFile().FilePath())] = true
+		}
+	}
+	return nil
+}

--- a/internal/iceberg/writer.go
+++ b/internal/iceberg/writer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,17 +32,24 @@ func WithMutationMode(mode MutationMode) WriterOption {
 	return func(w *Writer) { w.mutationMode = mode }
 }
 
+// WithTargetFileSizeBytes configures the approximate compressed Parquet target
+// size for each data file. Values <= 0 preserve single-file output.
+func WithTargetFileSizeBytes(size int64) WriterOption {
+	return func(w *Writer) { w.targetFileSizeBytes = size }
+}
+
 // Writer receives RowEvents, buffers them per table, and flushes to S3 + Iceberg.
 type Writer struct {
-	catalog       *Catalog
-	parquet       *pqbuilder.Builder
-	storage       storage.ObjectStorage
-	state         *state.Store
-	slotName      string
-	flushRows     int
-	flushInterval time.Duration
-	mutationMode  MutationMode
-	logger        *slog.Logger
+	catalog             *Catalog
+	parquet             *pqbuilder.Builder
+	storage             storage.ObjectStorage
+	state               *state.Store
+	slotName            string
+	flushRows           int
+	flushInterval       time.Duration
+	mutationMode        MutationMode
+	targetFileSizeBytes int64
+	logger              *slog.Logger
 
 	buffers map[string]*tableBuffer // key: "schema.table"
 }
@@ -430,7 +438,8 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 		buf.fieldIDs = fids
 	}
 
-	var dataFile *DataFile
+	var dataFiles []DataFile
+	var carriedDataFiles []DataFile
 	var eqDeleteFile *EqDeleteFile
 	replace := false
 	dataRows := buf.Rows
@@ -454,10 +463,10 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 				"delete_keys", len(deleteRows),
 			)
 		} else {
-			// Copy-on-write: read existing data, remove deleted rows, combine
-			// with new inserts, and write a replacement snapshot. Refuse to
-			// read an MOR table because readExistingRows intentionally skips
-			// delete manifests and would resurrect deleted rows.
+			// Copy-on-write: rewrite only active files whose key ranges may
+			// contain the pending delete/update keys. If bounds are absent or
+			// unsupported, candidate selection conservatively falls back to all
+			// active files.
 			hasDeletes, err := w.catalog.HasEqualityDeleteFiles(ctx, buf.Schema, buf.Table)
 			if err != nil {
 				return fmt.Errorf("check delete files for %s: %w", key, err)
@@ -467,7 +476,13 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 			}
 			replace = true
 
-			existingRows, err := w.readExistingRows(ctx, buf, cols)
+			activeFiles, err := w.catalog.GetActiveDataFiles(ctx, buf.Schema, buf.Table)
+			if err != nil {
+				return fmt.Errorf("list active files for %s: %w", key, err)
+			}
+			candidateFiles, carried, pruned := selectCOWFiles(activeFiles, buf, cols)
+			carriedDataFiles = carried
+			existingRows, err := w.readRowsFromFiles(ctx, candidateFiles, cols)
 			if err != nil {
 				return fmt.Errorf("COW read for %s: %w", key, err)
 			}
@@ -478,6 +493,10 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 
 			w.logger.Info("COW merge",
 				"table", key,
+				"active_files", len(activeFiles),
+				"candidate_files", len(candidateFiles),
+				"carried_files", len(carriedDataFiles),
+				"pruned", pruned,
 				"existing", len(existingRows),
 				"after_filter", len(filtered),
 				"new_rows", len(dedupedNew),
@@ -492,29 +511,29 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 		buf.Deletes = nil
 	}
 
-	// COW delete-all commits use the catalog's empty-table metadata path.
-	// MOR delete-only commits need no data file: the equality-delete file is
-	// sufficient.
 	if len(dataRows) > 0 {
-		dataFile, err = w.writeDataFile(ctx, key, buf, cols, dataRows)
+		dataFiles, err = w.writeDataFiles(ctx, key, buf, cols, dataRows)
 		if err != nil {
 			return err
 		}
 	}
 
-	if dataFile == nil && eqDeleteFile == nil && !replace {
+	if len(dataFiles) == 0 && eqDeleteFile == nil && !replace {
 		return fmt.Errorf("flush %s produced no data or delete file", key)
 	}
 
-	// Commit data and equality deletes atomically in one Iceberg snapshot.
-	if err := w.catalog.CommitChangeset(ctx, buf.Schema, buf.Table, dataFile, eqDeleteFile, replace, buf.LastLSN.String()); err != nil {
+	var eqDeleteFiles []EqDeleteFile
+	if eqDeleteFile != nil {
+		eqDeleteFiles = []EqDeleteFile{*eqDeleteFile}
+	}
+	if err := w.catalog.CommitChangesetFiles(ctx, buf.Schema, buf.Table, dataFiles, eqDeleteFiles, carriedDataFiles, replace, buf.LastLSN.String()); err != nil {
 		return fmt.Errorf("commit snapshot for %s: %w", key, err)
 	}
 
 	duration := time.Since(start)
 	var dataBytes, deleteBytes int64
-	if dataFile != nil {
-		dataBytes = dataFile.FileSize
+	for _, f := range dataFiles {
+		dataBytes += f.FileSize
 	}
 	if eqDeleteFile != nil {
 		deleteBytes = eqDeleteFile.FileSize
@@ -615,17 +634,55 @@ func (w *Writer) ComputePendingMinLSN() pglogrepl.LSN {
 	return min
 }
 
-func (w *Writer) writeDataFile(ctx context.Context, key string, buf *tableBuffer, cols []pqbuilder.ColumnDef, rows [][]pqbuilder.Value) (*DataFile, error) {
-	parquetData, err := w.parquet.Build(cols, rows)
+func (w *Writer) writeDataFiles(ctx context.Context, key string, buf *tableBuffer, cols []pqbuilder.ColumnDef, rows [][]pqbuilder.Value) ([]DataFile, error) {
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	chunks, err := w.splitRowsByTarget(cols, rows)
 	if err != nil {
-		return nil, fmt.Errorf("build parquet for %s: %w", key, err)
+		return nil, err
 	}
-	name := fmt.Sprintf("data/%s.parquet", uuid.New().String())
-	s3Key := fmt.Sprintf("%s/%s/%s/%s", w.catalog.prefix, buf.Schema, buf.Table, name)
-	if err := w.storage.PutObject(ctx, s3Key, parquetData, "application/octet-stream"); err != nil {
-		return nil, fmt.Errorf("upload parquet for %s: %w", key, err)
+	files := make([]DataFile, 0, len(chunks))
+	for _, chunk := range chunks {
+		parquetData, err := w.parquet.Build(cols, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("build parquet for %s: %w", key, err)
+		}
+		name := fmt.Sprintf("data/%s.parquet", uuid.New().String())
+		s3Key := fmt.Sprintf("%s/%s/%s/%s", w.catalog.prefix, buf.Schema, buf.Table, name)
+		if err := w.storage.PutObject(ctx, s3Key, parquetData, "application/octet-stream"); err != nil {
+			return nil, fmt.Errorf("upload parquet for %s: %w", key, err)
+		}
+		lower, upper := computeKeyBounds(buf, chunk)
+		files = append(files, DataFile{Path: name, RowCount: int64(len(chunk)), FileSize: int64(len(parquetData)), LowerBounds: lower, UpperBounds: upper})
 	}
-	return &DataFile{Path: name, RowCount: int64(len(rows)), FileSize: int64(len(parquetData))}, nil
+	return files, nil
+}
+
+func (w *Writer) splitRowsByTarget(cols []pqbuilder.ColumnDef, rows [][]pqbuilder.Value) ([][][]pqbuilder.Value, error) {
+	if w.targetFileSizeBytes <= 0 || len(rows) <= 1 {
+		return [][][]pqbuilder.Value{rows}, nil
+	}
+	all, err := w.parquet.Build(cols, rows)
+	if err != nil {
+		return nil, fmt.Errorf("estimate parquet size: %w", err)
+	}
+	if int64(len(all)) <= w.targetFileSizeBytes {
+		return [][][]pqbuilder.Value{rows}, nil
+	}
+	rowsPerFile := int(math.Floor(float64(len(rows)) * float64(w.targetFileSizeBytes) / float64(len(all))))
+	if rowsPerFile < 1 {
+		rowsPerFile = 1
+	}
+	var chunks [][][]pqbuilder.Value
+	for start := 0; start < len(rows); start += rowsPerFile {
+		end := start + rowsPerFile
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunks = append(chunks, rows[start:end])
+	}
+	return chunks, nil
 }
 
 func (w *Writer) writeEqualityDeleteFile(ctx context.Context, key string, buf *tableBuffer, rows [][]pqbuilder.Value) (*EqDeleteFile, error) {
@@ -673,13 +730,17 @@ func (w *Writer) writeEqualityDeleteFile(ctx context.Context, key string, buf *t
 // readExistingRows downloads all current data files for a table from S3
 // and parses them back to Value rows using the parquet reader.
 func (w *Writer) readExistingRows(ctx context.Context, buf *tableBuffer, cols []pqbuilder.ColumnDef) ([][]pqbuilder.Value, error) {
-	dataFilePaths, err := w.catalog.GetDataFilePaths(ctx, buf.Schema, buf.Table)
+	files, err := w.catalog.GetActiveDataFiles(ctx, buf.Schema, buf.Table)
 	if err != nil {
 		return nil, err
 	}
+	return w.readRowsFromFiles(ctx, files, cols)
+}
 
+func (w *Writer) readRowsFromFiles(ctx context.Context, files []DataFile, cols []pqbuilder.ColumnDef) ([][]pqbuilder.Value, error) {
 	var allRows [][]pqbuilder.Value
-	for _, filePath := range dataFilePaths {
+	for _, file := range files {
+		filePath := file.Path
 		s3Key := s3KeyFromURI(filePath)
 		fileData, err := w.storage.GetObject(ctx, s3Key)
 		if err != nil {


### PR DESCRIPTION
## Summary
- add target-size multi-file Parquet output for sync writes
- add conservative file-level COW pruning using key bounds, with fallback to full COW
- add snapshot expiration and dry-run orphan planning maintenance command

## Validation
- go test ./...
- go vet ./...
- go build ./cmd/streambed
- go test -tags integration -count=1 -v -timeout 20m -run ^TestMutationModesDuckDBCorrectness$ ./test/integration/...
- 10 MiB mutation benchmark smoke passed

Stacked on #31. Addresses #33, #34, #36.