### PR TITLE
Add small-file compaction

### DIFF
--- a/cmd/streambed/main.go
+++ b/cmd/streambed/main.go
@@ -119,7 +119,35 @@ This command does NOT touch the Postgres replication slot.`,
 	maintenanceCmd.Flags().StringVar(&cfg.S3Prefix, "s3-prefix", cfg.S3Prefix, "S3 key prefix")
 	maintenanceCmd.Flags().StringVar(&cfg.S3Endpoint, "s3-endpoint", cfg.S3Endpoint, "Custom S3 endpoint (MinIO)")
 	maintenanceCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
+	maintenanceCmd.Flags().StringVar(&cfg.StatePath, "state-path", cfg.StatePath, "SQLite state file path")
 	maintenanceCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
+
+	var compactTable string
+	var compactTargetMB int
+	var compactThresholdMB int
+	var compactMaxInputFiles int
+	var compactDryRun bool
+	var compactForce bool
+	compactCmd := &cobra.Command{
+		Use:   "compact",
+		Short: "Compact small Iceberg data files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMaintenanceCompact(cmd, compactTable, compactTargetMB, compactThresholdMB, compactMaxInputFiles, compactDryRun, compactForce)
+		},
+	}
+	compactCmd.Flags().StringVar(&compactTable, "table", "", "Table to compact as schema.table (required)")
+	compactCmd.Flags().IntVar(&compactTargetMB, "target-file-size-mb", cfg.TargetFileSizeMB, "Target compacted Parquet file size in MiB")
+	compactCmd.Flags().IntVar(&compactThresholdMB, "small-file-threshold-mb", 32, "Active data files smaller than this are candidates")
+	compactCmd.Flags().IntVar(&compactMaxInputFiles, "max-input-files", 1000, "Maximum number of input files for one compaction run")
+	compactCmd.Flags().BoolVar(&compactDryRun, "dry-run", true, "Only print compaction plan")
+	compactCmd.Flags().BoolVar(&compactForce, "force", false, "Apply compaction; required with --dry-run=false")
+	compactCmd.Flags().StringVar(&cfg.S3Bucket, "s3-bucket", cfg.S3Bucket, "S3 bucket name")
+	compactCmd.Flags().StringVar(&cfg.S3Prefix, "s3-prefix", cfg.S3Prefix, "S3 key prefix")
+	compactCmd.Flags().StringVar(&cfg.S3Endpoint, "s3-endpoint", cfg.S3Endpoint, "Custom S3 endpoint (MinIO)")
+	compactCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
+	compactCmd.Flags().StringVar(&cfg.StatePath, "state-path", cfg.StatePath, "SQLite state file path")
+	compactCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
+	maintenanceCmd.AddCommand(compactCmd)
 
 	var resyncTable string
 	var resyncForce bool
@@ -650,6 +678,83 @@ func runCleanup(cmd *cobra.Command, tables []string, dryRun, force bool) error {
 // runMaintenance expires old Iceberg snapshots and optionally removes objects
 // that are no longer reachable from retained metadata. It should not be run
 // concurrently with a writer for the same table/prefix.
+func runMaintenanceCompact(cmd *cobra.Command, tableRef string, targetMB, thresholdMB, maxInputFiles int, dryRun bool, force bool) error {
+	cfg := config.Load()
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		switch f.Name {
+		case "s3-bucket":
+			cfg.S3Bucket = f.Value.String()
+		case "s3-prefix":
+			cfg.S3Prefix = f.Value.String()
+		case "s3-endpoint":
+			cfg.S3Endpoint = f.Value.String()
+		case "s3-region":
+			cfg.S3Region = f.Value.String()
+		case "state-path":
+			cfg.StatePath = f.Value.String()
+		case "log-level":
+			cfg.LogLevel = f.Value.String()
+		}
+	})
+	if tableRef == "" {
+		return fmt.Errorf("--table schema.table is required")
+	}
+	parts := strings.Split(tableRef, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("invalid table %q, want schema.table", tableRef)
+	}
+	if !dryRun && !force {
+		return fmt.Errorf("--force is required when --dry-run=false")
+	}
+	if cfg.S3Bucket == "" {
+		return fmt.Errorf("s3-bucket is required")
+	}
+	ctx := context.Background()
+	s3Client, err := storage.NewS3Client(ctx, cfg.S3Bucket, cfg.S3Region, cfg.S3Endpoint)
+	if err != nil {
+		return fmt.Errorf("create S3 client: %w", err)
+	}
+	stateStore, err := state.Open(cfg.StatePath)
+	if err != nil {
+		return fmt.Errorf("open state store: %w", err)
+	}
+	defer stateStore.Close()
+	catalog := iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
+	opts := iceberg.CompactionOptions{
+		TargetFileSizeBytes:     int64(targetMB) * 1024 * 1024,
+		SmallFileThresholdBytes: int64(thresholdMB) * 1024 * 1024,
+		MaxInputFiles:           maxInputFiles,
+		DryRun:                  dryRun,
+	}
+	plan, result, err := iceberg.CompactSmallFiles(ctx, catalog, stateStore, opts, parts[0], parts[1])
+	if err != nil && !result.Aborted {
+		return err
+	}
+	fmt.Printf("Compaction plan for %s\n", tableRef)
+	fmt.Printf("  planned_snapshot: %d\n", plan.PlannedSnapshotID)
+	fmt.Printf("  active_delete_files: %d\n", plan.ActiveDeleteFileCount)
+	fmt.Printf("  input_files: %d\n", len(plan.InputFiles))
+	fmt.Printf("  input_bytes: %d\n", plan.InputBytes)
+	fmt.Printf("  estimated_output_files: %d\n", plan.EstimatedOutputFiles)
+	fmt.Printf("  dry_run: %v\n", dryRun)
+	if dryRun || len(plan.InputFiles) == 0 || plan.ActiveDeleteFileCount > 0 {
+		if result.AbortReason != "" {
+			fmt.Printf("  skipped: %s\n", result.AbortReason)
+		}
+		return err
+	}
+	fmt.Printf("Compacted %s\n", tableRef)
+	fmt.Printf("  validated_snapshot: %d\n", result.ValidatedSnapshotID)
+	fmt.Printf("  new_snapshot: %d\n", result.NewSnapshotID)
+	fmt.Printf("  output_files: %d\n", result.OutputFiles)
+	fmt.Printf("  output_bytes: %d\n", result.OutputBytes)
+	fmt.Printf("  carried_files: %d\n", result.CarriedFiles)
+	if result.Aborted {
+		fmt.Printf("  aborted: %s\n", result.AbortReason)
+	}
+	return err
+}
+
 func runMaintenance(cmd *cobra.Command, tables []string, retainLast int, includeOrphans bool, dryRun bool, force bool) error {
 	cfg := config.Load()
 	cmd.Flags().Visit(func(f *pflag.Flag) {
@@ -662,6 +767,8 @@ func runMaintenance(cmd *cobra.Command, tables []string, retainLast int, include
 			cfg.S3Endpoint = f.Value.String()
 		case "s3-region":
 			cfg.S3Region = f.Value.String()
+		case "state-path":
+			cfg.StatePath = f.Value.String()
 		case "log-level":
 			cfg.LogLevel = f.Value.String()
 		}
@@ -684,12 +791,39 @@ func runMaintenance(cmd *cobra.Command, tables []string, retainLast int, include
 		return fmt.Errorf("create S3 client: %w", err)
 	}
 	catalog := iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
+	var stateStore *state.Store
+	if !dryRun {
+		stateStore, err = state.Open(cfg.StatePath)
+		if err != nil {
+			return fmt.Errorf("open state store: %w", err)
+		}
+		defer stateStore.Close()
+	}
 	for _, tableRef := range tables {
 		parts := strings.Split(tableRef, ".")
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return fmt.Errorf("invalid table %q, want schema.table", tableRef)
 		}
+		var lock *state.TableCommitLock
+		if !dryRun {
+			lock, err = stateStore.AcquireTableCommitLock(ctx, parts[0], parts[1], "maintenance-expire", 5*time.Minute, 30*time.Second)
+			if err != nil {
+				return fmt.Errorf("acquire commit lock for %s: %w", tableRef, err)
+			}
+		}
+		if lock != nil {
+			ok, err := stateStore.RefreshTableCommitLock(ctx, lock, 5*time.Minute)
+			if err != nil {
+				return fmt.Errorf("refresh commit lock for %s: %w", tableRef, err)
+			}
+			if !ok {
+				return fmt.Errorf("commit lock for %s expired or was stolen", tableRef)
+			}
+		}
 		plan, err := catalog.ExpireSnapshots(ctx, parts[0], parts[1], retainLast, dryRun)
+		if lock != nil {
+			_ = stateStore.ReleaseTableCommitLock(context.Background(), lock)
+		}
 		if err != nil {
 			return fmt.Errorf("expire snapshots for %s: %w", tableRef, err)
 		}

--- a/internal/iceberg/compaction.go
+++ b/internal/iceberg/compaction.go
@@ -1,0 +1,593 @@
+package iceberg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	ice "github.com/apache/iceberg-go"
+	"github.com/google/uuid"
+	pqbuilder "github.com/viggy28/streambed/internal/parquet"
+	"github.com/viggy28/streambed/internal/state"
+)
+
+// CompactionOptions configures small-file compaction for one table.
+type CompactionOptions struct {
+	TargetFileSizeBytes     int64
+	SmallFileThresholdBytes int64
+	MaxInputFiles           int
+	DryRun                  bool
+}
+
+// CompactionPlan describes a planned small-file compaction. PlannedSnapshotID
+// is the snapshot used to choose input files and perform the rewrite.
+type CompactionPlan struct {
+	Schema                string
+	Table                 string
+	PlannedSnapshotID     int64
+	PlannedSchemaID       int
+	Columns               []pqbuilder.ColumnDef
+	InputFiles            []DataFile
+	InputBytes            int64
+	EstimatedOutputFiles  int
+	ActiveDeleteFileCount int
+	DryRun                bool
+}
+
+// CompactionResult describes the outcome of a small-file compaction.
+type CompactionResult struct {
+	PlannedSnapshotID   int64
+	ValidatedSnapshotID int64
+	NewSnapshotID       int64
+	InputFiles          int
+	OutputFiles         int
+	InputBytes          int64
+	OutputBytes         int64
+	CarriedFiles        int
+	Aborted             bool
+	AbortReason         string
+}
+
+// CompactSmallFiles plans and optionally applies clean data-file compaction.
+// It skips tables with active equality-delete files; MOR delete compaction is
+// handled separately.
+func CompactSmallFiles(ctx context.Context, catalog *Catalog, store *state.Store, opts CompactionOptions, schema, table string) (CompactionPlan, CompactionResult, error) {
+	plan, err := catalog.PlanSmallFileCompaction(ctx, schema, table, opts)
+	if err != nil || opts.DryRun || len(plan.InputFiles) == 0 || plan.ActiveDeleteFileCount > 0 {
+		return plan, CompactionResult{PlannedSnapshotID: plan.PlannedSnapshotID, InputFiles: len(plan.InputFiles), InputBytes: plan.InputBytes, Aborted: plan.ActiveDeleteFileCount > 0, AbortReason: abortReason(plan)}, err
+	}
+	outputs, err := catalog.writeCompactedDataFiles(ctx, schema, table, plan, opts)
+	if err != nil {
+		return plan, CompactionResult{PlannedSnapshotID: plan.PlannedSnapshotID, InputFiles: len(plan.InputFiles), InputBytes: plan.InputBytes, Aborted: true, AbortReason: err.Error()}, err
+	}
+	lock, err := store.AcquireTableCommitLock(ctx, schema, table, "maintenance-compact", 5*time.Minute, 30*time.Second)
+	if err != nil {
+		_ = catalog.deleteDataFiles(ctx, schema, table, outputs)
+		return plan, CompactionResult{PlannedSnapshotID: plan.PlannedSnapshotID, InputFiles: len(plan.InputFiles), OutputFiles: len(outputs), InputBytes: plan.InputBytes, Aborted: true, AbortReason: err.Error()}, err
+	}
+	defer store.ReleaseTableCommitLock(context.Background(), lock)
+	ok, err := store.RefreshTableCommitLock(ctx, lock, 5*time.Minute)
+	if err != nil {
+		return plan, CompactionResult{PlannedSnapshotID: plan.PlannedSnapshotID, InputFiles: len(plan.InputFiles), OutputFiles: len(outputs), InputBytes: plan.InputBytes, Aborted: true, AbortReason: err.Error()}, err
+	}
+	if !ok {
+		err := errors.New("commit lock expired or was stolen")
+		return plan, CompactionResult{PlannedSnapshotID: plan.PlannedSnapshotID, InputFiles: len(plan.InputFiles), OutputFiles: len(outputs), InputBytes: plan.InputBytes, Aborted: true, AbortReason: err.Error()}, err
+	}
+	result, err := catalog.CommitSmallFileCompaction(ctx, schema, table, plan, outputs)
+	// Do not delete outputs after a commit attempt returns an error: the publish
+	// outcome can be unknown if the final metadata pointer write timed out after
+	// succeeding. Definite pre-commit aborts are left for safe orphan cleanup.
+	return plan, result, err
+}
+
+func abortReason(plan CompactionPlan) string {
+	if plan.ActiveDeleteFileCount > 0 {
+		return "active equality delete files found; MOR compaction required"
+	}
+	return ""
+}
+
+func (c *Catalog) PlanSmallFileCompaction(ctx context.Context, schema, table string, opts CompactionOptions) (CompactionPlan, error) {
+	meta, _, _, err := c.readCurrentMetadata(ctx, schema, table)
+	if err != nil {
+		return CompactionPlan{}, err
+	}
+	cols, err := parquetColumnsFromMetadata(meta)
+	if err != nil {
+		return CompactionPlan{}, err
+	}
+	plan := CompactionPlan{Schema: schema, Table: table, PlannedSnapshotID: meta.CurrentSnapshotID, PlannedSchemaID: meta.CurrentSchemaID, Columns: cols, DryRun: opts.DryRun}
+	if meta.CurrentSnapshotID <= 0 {
+		return plan, nil
+	}
+	deleteCount, err := c.activeDeleteFileCount(ctx, meta)
+	if err != nil {
+		return plan, err
+	}
+	plan.ActiveDeleteFileCount = deleteCount
+	if deleteCount > 0 {
+		return plan, nil
+	}
+	files, err := c.activeDataFilesFromMetadata(ctx, meta)
+	if err != nil {
+		return plan, err
+	}
+	threshold := opts.SmallFileThresholdBytes
+	if threshold <= 0 {
+		threshold = opts.TargetFileSizeBytes / 4
+	}
+	if threshold <= 0 {
+		threshold = 32 * 1024 * 1024
+	}
+	maxFiles := opts.MaxInputFiles
+	if maxFiles <= 0 {
+		maxFiles = 1000
+	}
+	for _, f := range files {
+		if f.RowCount <= 0 || f.FileSize <= 0 || f.FileSize >= threshold {
+			continue
+		}
+		plan.InputFiles = append(plan.InputFiles, f)
+		plan.InputBytes += f.FileSize
+		if len(plan.InputFiles) >= maxFiles {
+			break
+		}
+	}
+	if opts.TargetFileSizeBytes > 0 && plan.InputBytes > 0 {
+		plan.EstimatedOutputFiles = int(math.Ceil(float64(plan.InputBytes) / float64(opts.TargetFileSizeBytes)))
+		if plan.EstimatedOutputFiles < 1 {
+			plan.EstimatedOutputFiles = 1
+		}
+	} else if len(plan.InputFiles) > 0 {
+		plan.EstimatedOutputFiles = 1
+	}
+	return plan, nil
+}
+
+func (c *Catalog) CommitSmallFileCompaction(ctx context.Context, schema, table string, plan CompactionPlan, outputs []DataFile) (CompactionResult, error) {
+	meta, _, _, err := c.readCurrentMetadata(ctx, schema, table)
+	if err != nil {
+		return CompactionResult{PlannedSnapshotID: plan.PlannedSnapshotID, Aborted: true, AbortReason: err.Error()}, err
+	}
+	result := CompactionResult{PlannedSnapshotID: plan.PlannedSnapshotID, ValidatedSnapshotID: meta.CurrentSnapshotID, InputFiles: len(plan.InputFiles), OutputFiles: len(outputs), InputBytes: plan.InputBytes}
+	if meta.CurrentSnapshotID <= 0 {
+		result.Aborted = true
+		result.AbortReason = "table has no current snapshot"
+		return result, errors.New(result.AbortReason)
+	}
+	if meta.CurrentSchemaID != plan.PlannedSchemaID {
+		result.Aborted = true
+		result.AbortReason = fmt.Sprintf("schema changed during compaction: planned=%d current=%d", plan.PlannedSchemaID, meta.CurrentSchemaID)
+		return result, errors.New(result.AbortReason)
+	}
+	deleteCount, err := c.activeDeleteFileCount(ctx, meta)
+	if err != nil {
+		result.Aborted = true
+		result.AbortReason = err.Error()
+		return result, err
+	}
+	if deleteCount > 0 {
+		result.Aborted = true
+		result.AbortReason = "active equality delete files found; MOR compaction required"
+		return result, errors.New(result.AbortReason)
+	}
+	latest, err := c.activeDataFilesFromMetadata(ctx, meta)
+	if err != nil {
+		result.Aborted = true
+		result.AbortReason = err.Error()
+		return result, err
+	}
+	inputSet := make(map[string]struct{}, len(plan.InputFiles))
+	for _, f := range plan.InputFiles {
+		inputSet[canonicalDataFilePath(f.Path)] = struct{}{}
+	}
+	for _, f := range plan.InputFiles {
+		if !dataFileInSet(latest, f.Path) {
+			result.Aborted = true
+			result.AbortReason = fmt.Sprintf("input file no longer active: %s", f.Path)
+			return result, errors.New(result.AbortReason)
+		}
+	}
+	carried := make([]DataFile, 0, len(latest))
+	for _, f := range latest {
+		if _, ok := inputSet[canonicalDataFilePath(f.Path)]; ok {
+			continue
+		}
+		carried = append(carried, f)
+	}
+	for _, f := range outputs {
+		result.OutputBytes += f.FileSize
+	}
+	result.CarriedFiles = len(carried)
+	flushLSN := currentSnapshotFlushLSN(meta)
+	if err := c.CommitChangesetFiles(ctx, schema, table, outputs, nil, carried, true, flushLSN); err != nil {
+		result.Aborted = true
+		result.AbortReason = err.Error()
+		return result, err
+	}
+	latestMeta, _, _, err := c.readCurrentMetadata(ctx, schema, table)
+	if err == nil {
+		result.NewSnapshotID = latestMeta.CurrentSnapshotID
+	}
+	return result, nil
+}
+
+func (c *Catalog) writeCompactedDataFiles(ctx context.Context, schema, table string, plan CompactionPlan, opts CompactionOptions) ([]DataFile, error) {
+	cols := plan.Columns
+	if len(cols) == 0 {
+		return nil, errors.New("compaction plan has no schema columns")
+	}
+	rows, err := c.readRowsFromDataFiles(ctx, schema, table, plan.InputFiles, cols)
+	if err != nil {
+		return nil, err
+	}
+	fieldIDs := boundedFieldIDs(plan.InputFiles)
+	if len(fieldIDs) > 0 {
+		sortRowsByFields(rows, cols, fieldIDs)
+	}
+	chunks, err := splitRowsByTarget(&pqbuilder.Builder{}, cols, rows, opts.TargetFileSizeBytes)
+	if err != nil {
+		return nil, err
+	}
+	basePath := c.tablePath(schema, table)
+	out := make([]DataFile, 0, len(chunks))
+	for _, chunk := range chunks {
+		if len(chunk) == 0 {
+			continue
+		}
+		data, err := (&pqbuilder.Builder{}).Build(cols, chunk)
+		if err != nil {
+			return nil, err
+		}
+		name := fmt.Sprintf("data/%s.parquet", uuid.NewString())
+		key := path.Join(basePath, name)
+		if err := c.storage.PutObject(ctx, key, data, "application/octet-stream"); err != nil {
+			return nil, err
+		}
+		lower, upper := computeBoundsForFields(cols, chunk, fieldIDs)
+		out = append(out, DataFile{Path: name, RowCount: int64(len(chunk)), FileSize: int64(len(data)), LowerBounds: lower, UpperBounds: upper})
+	}
+	return out, nil
+}
+
+func (c *Catalog) readRowsFromDataFiles(ctx context.Context, schema, table string, files []DataFile, cols []pqbuilder.ColumnDef) ([][]pqbuilder.Value, error) {
+	var rows [][]pqbuilder.Value
+	basePath := c.tablePath(schema, table)
+	for _, f := range files {
+		data, err := c.storage.GetObject(ctx, s3KeyFromURI(c.dataFileURI(basePath, f)))
+		if err != nil {
+			return nil, fmt.Errorf("download %s: %w", f.Path, err)
+		}
+		r, err := pqbuilder.ReadRows(data, cols)
+		if err != nil {
+			return nil, fmt.Errorf("read parquet %s: %w", f.Path, err)
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+
+func (c *Catalog) deleteDataFiles(ctx context.Context, schema, table string, files []DataFile) error {
+	if len(files) == 0 {
+		return nil
+	}
+	basePath := c.tablePath(schema, table)
+	keys := make([]string, 0, len(files))
+	for _, f := range files {
+		keys = append(keys, s3KeyFromURI(c.dataFileURI(basePath, f)))
+	}
+	return c.storage.DeleteObjects(ctx, keys)
+}
+
+func splitRowsByTarget(builder *pqbuilder.Builder, cols []pqbuilder.ColumnDef, rows [][]pqbuilder.Value, target int64) ([][][]pqbuilder.Value, error) {
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	if target <= 0 || len(rows) <= 1 {
+		return [][][]pqbuilder.Value{rows}, nil
+	}
+	all, err := builder.Build(cols, rows)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(all)) <= target {
+		return [][][]pqbuilder.Value{rows}, nil
+	}
+	rowsPerFile := int(math.Floor(float64(len(rows)) * float64(target) / float64(len(all))))
+	if rowsPerFile < 1 {
+		rowsPerFile = 1
+	}
+	var chunks [][][]pqbuilder.Value
+	for start := 0; start < len(rows); start += rowsPerFile {
+		end := start + rowsPerFile
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunks = append(chunks, rows[start:end])
+	}
+	return chunks, nil
+}
+
+func (c *Catalog) activeDataFilesFromMetadata(ctx context.Context, meta tableMetadata) ([]DataFile, error) {
+	if meta.CurrentSnapshotID <= 0 {
+		return nil, nil
+	}
+	var manifestListURI string
+	for _, snap := range meta.Snapshots {
+		if snap.SnapshotID == meta.CurrentSnapshotID {
+			manifestListURI = snap.ManifestList
+			break
+		}
+	}
+	if manifestListURI == "" {
+		return nil, nil
+	}
+	return c.dataFilesFromManifestList(ctx, manifestListURI)
+}
+
+func (c *Catalog) dataFilesFromManifestList(ctx context.Context, manifestListURI string) ([]DataFile, error) {
+	manifestListData, err := c.storage.GetObject(ctx, s3KeyFromURI(manifestListURI))
+	if err != nil {
+		return nil, err
+	}
+	manifests, err := readManifestListAvro(manifestListData)
+	if err != nil {
+		return nil, err
+	}
+	var files []DataFile
+	for _, mf := range manifests {
+		if mf.ManifestContent() != 0 { // data manifests only
+			continue
+		}
+		mfData, err := c.storage.GetObject(ctx, s3KeyFromURI(mf.FilePath()))
+		if err != nil {
+			return nil, err
+		}
+		entries, err := ice.ReadManifest(mf, bytes.NewReader(mfData), true)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.Status() == ice.EntryStatusDELETED {
+				continue
+			}
+			df := entry.DataFile()
+			files = append(files, DataFile{Path: df.FilePath(), RowCount: df.Count(), FileSize: df.FileSizeBytes(), LowerBounds: cloneBounds(df.LowerBoundValues()), UpperBounds: cloneBounds(df.UpperBoundValues())})
+		}
+	}
+	return files, nil
+}
+
+func (c *Catalog) activeDeleteFileCount(ctx context.Context, meta tableMetadata) (int, error) {
+	if meta.CurrentSnapshotID <= 0 {
+		return 0, nil
+	}
+	var manifestListURI string
+	for _, snap := range meta.Snapshots {
+		if snap.SnapshotID == meta.CurrentSnapshotID {
+			manifestListURI = snap.ManifestList
+			break
+		}
+	}
+	if manifestListURI == "" {
+		return 0, nil
+	}
+	manifestListData, err := c.storage.GetObject(ctx, s3KeyFromURI(manifestListURI))
+	if err != nil {
+		return 0, err
+	}
+	manifests, err := readManifestListAvro(manifestListData)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, mf := range manifests {
+		if mf.ManifestContent() != ice.ManifestContentDeletes {
+			continue
+		}
+		mfData, err := c.storage.GetObject(ctx, s3KeyFromURI(mf.FilePath()))
+		if err != nil {
+			return 0, err
+		}
+		entries, err := ice.ReadManifest(mf, bytes.NewReader(mfData), true)
+		if err != nil {
+			return 0, err
+		}
+		for _, entry := range entries {
+			if entry.Status() != ice.EntryStatusDELETED {
+				count++
+			}
+		}
+	}
+	return count, nil
+}
+
+func currentSnapshotFlushLSN(meta tableMetadata) string {
+	for _, snap := range meta.Snapshots {
+		if snap.SnapshotID == meta.CurrentSnapshotID {
+			return snap.Summary["streambed.last_flush_lsn"]
+		}
+	}
+	if meta.Properties != nil && meta.CurrentSnapshotID <= 0 {
+		return meta.Properties["streambed.last_flush_lsn"]
+	}
+	return ""
+}
+
+func dataFileInSet(files []DataFile, p string) bool {
+	want := canonicalDataFilePath(p)
+	for _, f := range files {
+		if canonicalDataFilePath(f.Path) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalDataFilePath(p string) string {
+	if strings.HasPrefix(p, "s3://") {
+		return p
+	}
+	return strings.TrimPrefix(p, "/")
+}
+
+func parquetColumnsFromMetadata(meta tableMetadata) ([]pqbuilder.ColumnDef, error) {
+	var fields []schemaField
+	for _, s := range meta.Schemas {
+		if s.SchemaID == meta.CurrentSchemaID {
+			fields = s.Fields
+			break
+		}
+	}
+	if fields == nil {
+		return nil, fmt.Errorf("current schema %d not found", meta.CurrentSchemaID)
+	}
+	cols := make([]pqbuilder.ColumnDef, len(fields))
+	for i, f := range fields {
+		cols[i] = pqbuilder.ColumnDef{Name: f.Name, OID: oidFromIcebergType(f.Type), FieldID: f.ID}
+	}
+	return cols, nil
+}
+
+func oidFromIcebergType(t string) uint32 {
+	switch t {
+	case TypeBoolean:
+		return 16
+	case TypeInt:
+		return 23
+	case TypeLong:
+		return 20
+	case TypeFloat:
+		return 700
+	case TypeDouble:
+		return 701
+	case TypeDate:
+		return 1082
+	case TypeTimestamp:
+		return 1114
+	case TypeTimestampTZ:
+		return 1184
+	case TypeUUID:
+		return 2950
+	case TypeBinary:
+		return 17
+	default:
+		return 25
+	}
+}
+
+func boundedFieldIDs(files []DataFile) []int {
+	if len(files) == 0 {
+		return nil
+	}
+	set := make(map[int]struct{})
+	for id := range files[0].LowerBounds {
+		if _, ok := files[0].UpperBounds[id]; ok {
+			set[id] = struct{}{}
+		}
+	}
+	for _, f := range files[1:] {
+		for id := range set {
+			if _, ok := f.LowerBounds[id]; !ok {
+				delete(set, id)
+				continue
+			}
+			if _, ok := f.UpperBounds[id]; !ok {
+				delete(set, id)
+			}
+		}
+	}
+	ids := make([]int, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	return ids
+}
+
+func computeBoundsForFields(cols []pqbuilder.ColumnDef, rows [][]pqbuilder.Value, fieldIDs []int) (map[int][]byte, map[int][]byte) {
+	if len(fieldIDs) == 0 || len(rows) == 0 {
+		return nil, nil
+	}
+	idSet := make(map[int]struct{}, len(fieldIDs))
+	for _, id := range fieldIDs {
+		idSet[id] = struct{}{}
+	}
+	lower, upper := make(map[int][]byte), make(map[int][]byte)
+	for _, row := range rows {
+		for i, col := range cols {
+			if _, ok := idSet[col.FieldID]; !ok || i >= len(row) {
+				continue
+			}
+			b, ok := encodeBoundValue(col.OID, row[i])
+			if !ok {
+				delete(idSet, col.FieldID)
+				delete(lower, col.FieldID)
+				delete(upper, col.FieldID)
+				continue
+			}
+			if cur, ok := lower[col.FieldID]; !ok || compareEncodedBound(col.OID, b, cur) < 0 {
+				lower[col.FieldID] = append([]byte(nil), b...)
+			}
+			if cur, ok := upper[col.FieldID]; !ok || compareEncodedBound(col.OID, b, cur) > 0 {
+				upper[col.FieldID] = append([]byte(nil), b...)
+			}
+		}
+	}
+	if len(lower) == 0 || len(upper) == 0 {
+		return nil, nil
+	}
+	return lower, upper
+}
+
+func sortRowsByFields(rows [][]pqbuilder.Value, cols []pqbuilder.ColumnDef, fieldIDs []int) {
+	if len(rows) < 2 || len(fieldIDs) == 0 {
+		return
+	}
+	indexes := make([]int, 0, len(fieldIDs))
+	for _, id := range fieldIDs {
+		for i, col := range cols {
+			if col.FieldID == id {
+				indexes = append(indexes, i)
+				break
+			}
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		for _, idx := range indexes {
+			if idx >= len(rows[i]) || idx >= len(rows[j]) {
+				continue
+			}
+			cmp := compareRowValue(cols[idx].OID, rows[i][idx], rows[j][idx])
+			if cmp != 0 {
+				return cmp < 0
+			}
+		}
+		return false
+	})
+}
+
+func compareRowValue(oid uint32, a, b pqbuilder.Value) int {
+	if a.IsNull && b.IsNull {
+		return 0
+	}
+	if a.IsNull {
+		return -1
+	}
+	if b.IsNull {
+		return 1
+	}
+	ab, aok := encodeBoundValue(oid, a)
+	bb, bok := encodeBoundValue(oid, b)
+	if aok && bok {
+		return compareEncodedBound(oid, ab, bb)
+	}
+	return strings.Compare(string(a.Data), string(b.Data))
+}

--- a/internal/iceberg/cow_layout_test.go
+++ b/internal/iceberg/cow_layout_test.go
@@ -105,6 +105,225 @@ func TestCOWFileLevelRewritePrunesUnaffectedFiles(t *testing.T) {
 	}
 }
 
+func TestSmallFileCompactionReducesActiveFiles(t *testing.T) {
+	w, mem := testWriter(t)
+	ctx := context.Background()
+	for i := 1; i <= 24; i++ {
+		if _, err := w.HandleEvent(ctx, insertEvent("public", "compact", pglogrepl.LSN(i), strconv.Itoa(i), fmt.Sprintf("name-%04d-xxxxxxxxxxxxxxxxxxxxxxxx", i))); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.FlushAll(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before, err := w.catalog.GetActiveDataFiles(ctx, "public", "compact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before) < 10 {
+		t.Fatalf("setup active files=%d, want many small files", len(before))
+	}
+	plan, result, err := CompactSmallFiles(ctx, w.catalog, w.state, CompactionOptions{
+		TargetFileSizeBytes:     700,
+		SmallFileThresholdBytes: 10 * 1024,
+		MaxInputFiles:           100,
+		DryRun:                  false,
+	}, "public", "compact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Aborted {
+		t.Fatalf("compaction aborted: %s", result.AbortReason)
+	}
+	if len(plan.InputFiles) != len(before) {
+		t.Fatalf("input files=%d, before=%d", len(plan.InputFiles), len(before))
+	}
+	after, err := w.catalog.GetActiveDataFiles(ctx, "public", "compact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) >= len(before) {
+		t.Fatalf("active files not reduced: before=%d after=%d", len(before), len(after))
+	}
+	cols := []pqbuilder.ColumnDef{{Name: "id", OID: 23, FieldID: 1}, {Name: "name", OID: 25, FieldID: 2}}
+	var total int
+	for _, f := range after {
+		data, err := mem.GetObject(ctx, s3KeyFromURI(w.catalog.dataFileURI(w.catalog.tablePath("public", "compact"), f)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows, err := pqbuilder.ReadRows(data, cols)
+		if err != nil {
+			t.Fatal(err)
+		}
+		total += len(rows)
+		if len(f.LowerBounds) == 0 || len(f.UpperBounds) == 0 {
+			t.Fatalf("compacted file %s missing bounds", f.Path)
+		}
+	}
+	if total != 24 {
+		t.Fatalf("rows after compaction=%d, want 24", total)
+	}
+	lsn, found, err := w.catalog.GetSnapshotFlushLSN(ctx, "public", "compact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || lsn == "" {
+		t.Fatalf("compaction did not preserve last flush LSN: found=%v lsn=%q", found, lsn)
+	}
+}
+
+func TestSmallFileCompactionCarriesConcurrentAppend(t *testing.T) {
+	w, _ := testWriter(t)
+	ctx := context.Background()
+	for i := 1; i <= 6; i++ {
+		if _, err := w.HandleEvent(ctx, insertEvent("public", "append", pglogrepl.LSN(i), strconv.Itoa(i), "old")); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.FlushAll(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plan, err := w.catalog.PlanSmallFileCompaction(ctx, "public", "append", CompactionOptions{TargetFileSizeBytes: 700, SmallFileThresholdBytes: 10 * 1024, MaxInputFiles: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs, err := w.catalog.writeCompactedDataFiles(ctx, "public", "append", plan, CompactionOptions{TargetFileSizeBytes: 700})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.HandleEvent(ctx, insertEvent("public", "append", 100, "99", "new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := w.state.AcquireTableCommitLock(ctx, "public", "append", "test", 5*time.Minute, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := w.catalog.CommitSmallFileCompaction(ctx, "public", "append", plan, outputs)
+	_ = w.state.ReleaseTableCommitLock(ctx, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ValidatedSnapshotID == plan.PlannedSnapshotID {
+		t.Fatal("validated snapshot did not advance after concurrent append")
+	}
+	paths, err := w.catalog.GetDataFilePaths(ctx, "public", "append")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cols := []pqbuilder.ColumnDef{{Name: "id", OID: 23, FieldID: 1}, {Name: "name", OID: 25, FieldID: 2}}
+	seenNew := false
+	var total int
+	for _, p := range paths {
+		data, err := w.storage.GetObject(ctx, s3KeyFromURI(p))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows, err := pqbuilder.ReadRows(data, cols)
+		if err != nil {
+			t.Fatal(err)
+		}
+		total += len(rows)
+		for _, r := range rows {
+			if string(r[0].Data) == "99" {
+				seenNew = true
+			}
+		}
+	}
+	if total != 7 || !seenNew {
+		t.Fatalf("total=%d seenNew=%v", total, seenNew)
+	}
+}
+
+func TestSmallFileCompactionAbortsWhenInputRewritten(t *testing.T) {
+	w, _ := testWriter(t)
+	ctx := context.Background()
+	for i := 1; i <= 6; i++ {
+		if _, err := w.HandleEvent(ctx, insertEvent("public", "conflict", pglogrepl.LSN(i), strconv.Itoa(i), "old")); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.FlushAll(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plan, err := w.catalog.PlanSmallFileCompaction(ctx, "public", "conflict", CompactionOptions{TargetFileSizeBytes: 700, SmallFileThresholdBytes: 10 * 1024, MaxInputFiles: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs, err := w.catalog.writeCompactedDataFiles(ctx, "public", "conflict", plan, CompactionOptions{TargetFileSizeBytes: 700})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Rewrite one planned input file through COW before the compaction commit.
+	// Updating all known setup IDs guarantees at least one planned input file is
+	// replaced regardless of manifest ordering.
+	for i := 1; i <= 6; i++ {
+		id := strconv.Itoa(i)
+		if _, err := w.HandleEvent(ctx, updateEvent("public", "conflict", pglogrepl.LSN(100+i), id, id, "updated")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := w.state.AcquireTableCommitLock(ctx, "public", "conflict", "test", 5*time.Minute, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := w.catalog.CommitSmallFileCompaction(ctx, "public", "conflict", plan, outputs)
+	_ = w.state.ReleaseTableCommitLock(ctx, lock)
+	if err == nil || !result.Aborted {
+		t.Fatalf("expected abort, result=%+v err=%v", result, err)
+	}
+}
+
+func TestSmallFileCompactionSkipsActiveEqualityDeletes(t *testing.T) {
+	ctx := context.Background()
+	mem := storage.NewMemS3Client("test-bucket")
+	catalog := NewCatalog(mem, "test-bucket", "test-prefix")
+	store := testStateStore(t)
+	w := NewWriter(catalog, mem, store, "test_slot", 10000, 2*time.Second, testLogger(), WithMutationMode(MutationModeMOR))
+	if _, err := w.HandleEvent(ctx, insertEvent("public", "morcompact", 1, "1", "old")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.HandleEvent(ctx, updateEvent("public", "morcompact", 2, "1", "1", "new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	plan, result, err := CompactSmallFiles(ctx, catalog, store, CompactionOptions{TargetFileSizeBytes: 1024, SmallFileThresholdBytes: 10 * 1024}, "public", "morcompact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.ActiveDeleteFileCount == 0 || !result.Aborted {
+		t.Fatalf("expected active deletes skip, plan=%+v result=%+v", plan, result)
+	}
+}
+
+func TestCompactionSortRowsByFieldsIsTypeAware(t *testing.T) {
+	cols := []pqbuilder.ColumnDef{{Name: "id", OID: 23, FieldID: 1}}
+	rows := [][]pqbuilder.Value{
+		{{Data: []byte("10")}},
+		{{Data: []byte("2")}},
+		{{Data: []byte("1")}},
+	}
+	sortRowsByFields(rows, cols, []int{1})
+	got := []string{string(rows[0][0].Data), string(rows[1][0].Data), string(rows[2][0].Data)}
+	want := []string{"1", "2", "10"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sorted ids=%v, want %v", got, want)
+		}
+	}
+}
+
 func TestSnapshotExpirationAndOrphanDryRun(t *testing.T) {
 	w, mem := testWriter(t)
 	ctx := context.Background()

--- a/internal/iceberg/writer.go
+++ b/internal/iceberg/writer.go
@@ -80,6 +80,36 @@ type tableBuffer struct {
 	deletedKeys map[string]bool
 }
 
+func (w *Writer) acquireCommitLock(ctx context.Context, schema, table string) (*state.TableCommitLock, error) {
+	if w.state == nil {
+		return nil, nil
+	}
+	return w.state.AcquireTableCommitLock(ctx, schema, table, "sync", 5*time.Minute, 30*time.Second)
+}
+
+func (w *Writer) refreshCommitLock(ctx context.Context, table string, lock *state.TableCommitLock) error {
+	if w.state == nil || lock == nil {
+		return nil
+	}
+	ok, err := w.state.RefreshTableCommitLock(ctx, lock, 5*time.Minute)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("commit lock for %s expired or was stolen", table)
+	}
+	return nil
+}
+
+func (w *Writer) releaseCommitLock(table string, lock *state.TableCommitLock) {
+	if w.state == nil || lock == nil {
+		return
+	}
+	if err := w.state.ReleaseTableCommitLock(context.Background(), lock); err != nil {
+		w.logger.Warn("release commit lock failed", "table", table, "error", err)
+	}
+}
+
 func NewWriter(
 	catalog *Catalog,
 	s3Client storage.ObjectStorage,
@@ -172,6 +202,14 @@ func (w *Writer) HandleSchemaChange(ctx context.Context, rel *wal.RelationMessag
 	}
 
 	if tableExists {
+		commitLock, err := w.acquireCommitLock(ctx, rel.Namespace, rel.Name)
+		if err != nil {
+			return fmt.Errorf("acquire commit lock for schema evolution %s: %w", key, err)
+		}
+		defer w.releaseCommitLock(key, commitLock)
+		if err := w.refreshCommitLock(ctx, key, commitLock); err != nil {
+			return fmt.Errorf("refresh commit lock for schema evolution %s: %w", key, err)
+		}
 		fids, err := w.catalog.EvolveSchema(ctx, rel.Namespace, rel.Name,
 			rel.Changes, rel.Columns, defaults)
 		if err != nil {
@@ -393,6 +431,15 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 		}
 	}
 
+	// Coordinate metadata-changing work with maintenance. The lock is held for
+	// the whole flush so COW reads/replacements cannot race a compaction commit.
+	var err error
+	commitLock, err := w.acquireCommitLock(ctx, buf.Schema, buf.Table)
+	if err != nil {
+		return fmt.Errorf("acquire commit lock for %s: %w", key, err)
+	}
+	defer w.releaseCommitLock(key, commitLock)
+
 	// Ensure Iceberg table exists before writing anything.
 	tableExists, err := w.catalog.TableExists(ctx, buf.Schema, buf.Table)
 	if err != nil {
@@ -526,6 +573,9 @@ func (w *Writer) flush(ctx context.Context, key string) error {
 	if eqDeleteFile != nil {
 		eqDeleteFiles = []EqDeleteFile{*eqDeleteFile}
 	}
+	if err := w.refreshCommitLock(ctx, key, commitLock); err != nil {
+		return fmt.Errorf("refresh commit lock for %s: %w", key, err)
+	}
 	if err := w.catalog.CommitChangesetFiles(ctx, buf.Schema, buf.Table, dataFiles, eqDeleteFiles, carriedDataFiles, replace, buf.LastLSN.String()); err != nil {
 		return fmt.Errorf("commit snapshot for %s: %w", key, err)
 	}
@@ -600,6 +650,16 @@ func (w *Writer) Truncate(ctx context.Context, event wal.RowEvent) error {
 			"lsn", event.WALStartLSN.String(),
 		)
 		return nil
+	}
+
+	commitLock, err := w.acquireCommitLock(ctx, event.Schema, event.Table)
+	if err != nil {
+		return fmt.Errorf("acquire commit lock for truncate %s: %w", key, err)
+	}
+	defer w.releaseCommitLock(key, commitLock)
+
+	if err := w.refreshCommitLock(ctx, key, commitLock); err != nil {
+		return fmt.Errorf("refresh commit lock for truncate %s: %w", key, err)
 	}
 
 	// replace=true, dataFile=nil → catalog writes an empty-manifest

--- a/internal/resync/resync.go
+++ b/internal/resync/resync.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -131,6 +132,14 @@ func Run(ctx context.Context, opts Options) (Stats, error) {
 		if len(batch) == 0 {
 			return nil
 		}
+		var lock *state.TableCommitLock
+		if opts.State != nil {
+			lock, err = opts.State.AcquireTableCommitLock(ctx, opts.Schema, opts.Table, "resync", 5*time.Minute, 30*time.Second)
+			if err != nil {
+				return fmt.Errorf("acquire commit lock: %w", err)
+			}
+			defer opts.State.ReleaseTableCommitLock(context.Background(), lock)
+		}
 		if !tableCreated {
 			exists, err := opts.Catalog.TableExists(ctx, opts.Schema, opts.Table)
 			if err != nil {
@@ -153,6 +162,15 @@ func Run(ctx context.Context, opts Options) (Stats, error) {
 
 		if err := opts.S3.PutObject(ctx, s3Key, parquetData, "application/octet-stream"); err != nil {
 			return fmt.Errorf("upload parquet: %w", err)
+		}
+		if lock != nil {
+			ok, err := opts.State.RefreshTableCommitLock(ctx, lock, 5*time.Minute)
+			if err != nil {
+				return fmt.Errorf("refresh commit lock: %w", err)
+			}
+			if !ok {
+				return fmt.Errorf("commit lock expired or was stolen")
+			}
 		}
 		if err := opts.Catalog.CommitSnapshot(ctx, opts.Schema, opts.Table, iceberg.DataFile{
 			Path:     dataFileName,

--- a/internal/state/lock_test.go
+++ b/internal/state/lock_test.go
@@ -1,0 +1,105 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestTableCommitLockAcquireRelease(t *testing.T) {
+	store, err := Open(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	lock, err := store.AcquireTableCommitLock(ctx, "public", "t", "test", time.Minute, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AcquireTableCommitLock(ctx, "public", "t", "test", time.Minute, 0); err == nil {
+		t.Fatal("expected second acquire to time out")
+	}
+	if err := store.ReleaseTableCommitLock(ctx, lock); err != nil {
+		t.Fatal(err)
+	}
+	lock2, err := store.AcquireTableCommitLock(ctx, "public", "t", "test", time.Minute, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = store.ReleaseTableCommitLock(ctx, lock2)
+}
+
+func TestTableCommitLockExpiredCanBeStolen(t *testing.T) {
+	store, err := Open(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	lock, err := store.AcquireTableCommitLock(ctx, "public", "t", "test", time.Nanosecond, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Millisecond)
+	stolen, err := store.AcquireTableCommitLock(ctx, "public", "t", "test", time.Minute, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stolen.Owner == lock.Owner {
+		t.Fatal("expected new owner after stealing expired lock")
+	}
+	_ = store.ReleaseTableCommitLock(ctx, stolen)
+}
+
+func TestRefreshTableCommitLockRequiresCurrentOwner(t *testing.T) {
+	store, err := Open(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	lock, err := store.AcquireTableCommitLock(ctx, "public", "t", "sync", time.Minute, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := lock.Owner; len(got) < len("sync:") || got[:len("sync:")] != "sync:" {
+		t.Fatalf("owner %q missing prefix", got)
+	}
+	ok, err := store.RefreshTableCommitLock(ctx, lock, time.Minute)
+	if err != nil || !ok {
+		t.Fatalf("refresh owner ok=%v err=%v", ok, err)
+	}
+	wrong := *lock
+	wrong.Owner = "someone-else"
+	ok, err = store.RefreshTableCommitLock(ctx, &wrong, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("wrong owner refreshed lock")
+	}
+	_ = store.ReleaseTableCommitLock(ctx, lock)
+}
+
+func TestReleaseTableCommitLockRequiresOwner(t *testing.T) {
+	store, err := Open(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	lock, err := store.AcquireTableCommitLock(ctx, "public", "t", "test", time.Minute, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := *lock
+	wrong.Owner = "someone-else"
+	if err := store.ReleaseTableCommitLock(ctx, &wrong); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AcquireTableCommitLock(ctx, "public", "t", "test", time.Minute, 0); err == nil {
+		t.Fatal("wrong owner released lock")
+	}
+	_ = store.ReleaseTableCommitLock(ctx, lock)
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,11 +1,14 @@
 package state
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pglogrepl"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -47,6 +50,14 @@ func createTables(db *sql.DB) error {
 			first_seen     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			last_flush     TIMESTAMP,
 			last_flush_lsn TEXT,
+			PRIMARY KEY (schema_name, table_name)
+		);
+		CREATE TABLE IF NOT EXISTS table_commit_locks (
+			schema_name TEXT NOT NULL,
+			table_name  TEXT NOT NULL,
+			owner       TEXT NOT NULL,
+			expires_at  INTEGER NOT NULL,
+			updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (schema_name, table_name)
 		);
 	`); err != nil {
@@ -101,7 +112,6 @@ func containsCI(s, sub string) bool {
 	return false
 }
 
-
 func (s *Store) RegisterTable(schema, table string, columnCount int) error {
 	_, err := s.db.Exec(`
 		INSERT INTO synced_tables (schema_name, table_name, column_count)
@@ -110,7 +120,6 @@ func (s *Store) RegisterTable(schema, table string, columnCount int) error {
 	`, schema, table, columnCount, columnCount)
 	return err
 }
-
 
 // RegisteredTable holds a registered table's schema and name.
 type RegisteredTable struct {
@@ -198,6 +207,94 @@ func (s *Store) ClearBackfillLSN(schema, table string) error {
 		`UPDATE synced_tables SET backfill_lsn = NULL WHERE schema_name = ? AND table_name = ?`,
 		schema, table,
 	)
+	return err
+}
+
+// TableCommitLock represents ownership of a short critical section that
+// publishes Iceberg metadata for one table. The lock is local to the shared
+// SQLite state database; all writers/maintenance processes for a table must
+// use the same state DB for this to coordinate them.
+type TableCommitLock struct {
+	Schema string
+	Table  string
+	Owner  string
+}
+
+// AcquireTableCommitLock waits up to wait for a table-level commit lock. The
+// lock expires after ttl so a crashed process does not block maintenance
+// forever. The caller must release the returned lock.
+func (s *Store) AcquireTableCommitLock(ctx context.Context, schema, table, ownerName string, ttl, wait time.Duration) (*TableCommitLock, error) {
+	if ttl <= 0 {
+		return nil, fmt.Errorf("commit lock ttl must be positive")
+	}
+	if wait < 0 {
+		return nil, fmt.Errorf("commit lock wait must be non-negative")
+	}
+	if ownerName == "" {
+		ownerName = "unknown"
+	}
+	owner := fmt.Sprintf("%s:%d:%s", ownerName, os.Getpid(), uuid.NewString())
+	deadline := time.Now().Add(wait)
+	for {
+		now := time.Now()
+		expires := now.Add(ttl).UnixMilli()
+		res, err := s.db.ExecContext(ctx, `
+			INSERT INTO table_commit_locks (schema_name, table_name, owner, expires_at, updated_at)
+			VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(schema_name, table_name) DO UPDATE SET
+				owner = excluded.owner,
+				expires_at = excluded.expires_at,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE table_commit_locks.expires_at < ?
+		`, schema, table, owner, expires, now.UnixMilli())
+		if err != nil {
+			return nil, err
+		}
+		if n, _ := res.RowsAffected(); n > 0 {
+			return &TableCommitLock{Schema: schema, Table: table, Owner: owner}, nil
+		}
+		if wait == 0 || time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out acquiring commit lock for %s.%s", schema, table)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// RefreshTableCommitLock verifies that the caller still owns an unexpired lock
+// and extends its expiry. It returns false if the lock was stolen or expired.
+func (s *Store) RefreshTableCommitLock(ctx context.Context, lock *TableCommitLock, ttl time.Duration) (bool, error) {
+	if lock == nil {
+		return false, nil
+	}
+	if ttl <= 0 {
+		return false, fmt.Errorf("commit lock ttl must be positive")
+	}
+	now := time.Now()
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE table_commit_locks
+		SET expires_at = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE schema_name = ? AND table_name = ? AND owner = ? AND expires_at > ?
+	`, now.Add(ttl).UnixMilli(), lock.Schema, lock.Table, lock.Owner, now.UnixMilli())
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// ReleaseTableCommitLock releases a lock if the caller still owns it.
+func (s *Store) ReleaseTableCommitLock(ctx context.Context, lock *TableCommitLock) error {
+	if lock == nil {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM table_commit_locks
+		WHERE schema_name = ? AND table_name = ? AND owner = ?
+	`, lock.Schema, lock.Table, lock.Owner)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- add SQLite-backed table commit locks for local writer/maintenance coordination
- add `streambed maintenance compact` for clean small data-file compaction
- compact clean active data files into fewer target-sized Parquet files while preserving snapshot LSNs
- validate planned input files are still active under the commit lock before publishing
- skip tables with active equality-delete files; MOR delete compaction remains #32

## Validation
- go test ./...
- go vet ./...
- go build ./cmd/streambed
- go test -tags integration -count=1 -v -timeout 20m -run ^TestMutationModesDuckDBCorrectness$ ./test/integration/...

Stacked on #41. Addresses #48.