### PR TITLE
Document maintenance and compaction commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,7 +28,8 @@ jobs:
       - name: Unit tests
         run: go test -race ./internal/... ./config/...
 
-  integration-test:
+  integration-smoke:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,8 +43,55 @@ jobs:
           docker compose -f test/integration/docker-compose.yml up -d postgres minio --wait
           docker compose -f test/integration/docker-compose.yml up createbucket
 
-      - name: Integration tests
-        run: go test -tags integration -short -v -timeout 900s ./test/integration/...
+      - name: Integration smoke tests
+        run: >
+          go test -tags integration -short -v -timeout 8m
+          -run 'TestEndToEnd$|TestEndToEndUpdateDelete$|TestSchemaEvolution_AddColumn$|TestMutationModesDuckDBCorrectness/cow$'
+          ./test/integration
+
+      - name: Stop services
+        if: always()
+        run: docker compose -f test/integration/docker-compose.yml down -v
+
+  integration-full:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start services
+        run: |
+          docker compose -f test/integration/docker-compose.yml up -d postgres minio --wait
+          docker compose -f test/integration/docker-compose.yml up createbucket
+
+      - name: Full integration tests
+        run: go test -tags integration -short -v -timeout 30m ./test/integration/...
+
+      - name: Stop services
+        if: always()
+        run: docker compose -f test/integration/docker-compose.yml down -v
+
+  integration-expensive:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start services
+        run: |
+          docker compose -f test/integration/docker-compose.yml up -d postgres minio --wait
+          docker compose -f test/integration/docker-compose.yml up createbucket
+
+      - name: Expensive integration tests
+        run: go test -tags integration -v -timeout 60m ./test/integration/...
 
       - name: Stop services
         if: always()

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ psql -h localhost -p 5433 -U postgres -d postgres
 
 Run `streambed sync --help` for all configuration options. All flags support environment variables with `STREAMBED_` prefix (e.g. `STREAMBED_SOURCE_URL`). UPDATE/DELETE use copy-on-write by default; opt into Iceberg v2 equality deletes with `--mutation-mode=mor` (or `STREAMBED_MUTATION_MODE=mor`) after verifying reader compatibility. Once a table has active equality deletes, Streambed fails startup in COW mode; continue using MOR.
 
+Use `--target-file-size-mb` (or `STREAMBED_TARGET_FILE_SIZE_MB`) to split large flushes into approximately target-sized Parquet data files. The default is 128 MiB. This is a target, not a hard maximum; small flushes still create small files.
+
 ## Architecture
 
 ![Architecture](/docs/architecture.svg)
@@ -66,7 +68,11 @@ A query server exposes Iceberg tables over the Postgres wire protocol using embe
 | `streambed resync --table=public.users` | One-shot backfill via `COPY` under a consistent snapshot. |
 | `streambed query` | Standalone query server (no sync). Points at existing Iceberg tables. |
 | `streambed cleanup --table=public.users` | Deletes S3 objects and state for a table. Useful before `resync`. |
+| `streambed maintenance --table=public.users` | Expires old Iceberg snapshots and can dry-run orphan planning. |
+| `streambed maintenance compact --table=public.users` | Compacts many small active data files into fewer target-sized files. |
 
+
+See [docs/maintenance.md](docs/maintenance.md) for snapshot expiration and small-file compaction details.
 
 ## Development
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,66 @@
+# Maintenance
+
+Streambed includes maintenance commands for Iceberg table metadata and file layout.
+
+## Snapshot expiration
+
+```bash
+streambed maintenance \
+  --table public.users \
+  --retain-last 1 \
+  --dry-run
+```
+
+Apply snapshot expiration:
+
+```bash
+streambed maintenance \
+  --table public.users \
+  --retain-last 1 \
+  --dry-run=false \
+  --force
+```
+
+Snapshot expiration removes old snapshot references from Iceberg metadata. It does not immediately delete all old data files unless they are part of the expiration plan. Orphan deletion is intentionally dry-run only until safer age/locking support is added.
+
+## Small-file compaction
+
+Frequent CDC flushes can create many small Parquet files. Small-file compaction rewrites clean active data files into fewer target-sized files:
+
+```bash
+streambed maintenance compact \
+  --table public.users \
+  --target-file-size-mb 128 \
+  --small-file-threshold-mb 32 \
+  --max-input-files 1000 \
+  --dry-run
+```
+
+Apply compaction:
+
+```bash
+streambed maintenance compact \
+  --table public.users \
+  --target-file-size-mb 128 \
+  --small-file-threshold-mb 32 \
+  --max-input-files 1000 \
+  --dry-run=false \
+  --force
+```
+
+Compaction currently handles clean active data files only. If a table has active MOR equality delete files, compaction skips the table; use future MOR compaction work to merge delete files into clean data files.
+
+## Safety notes
+
+Online maintenance uses a SQLite-backed table commit lock. This coordinates with `streambed sync` only when both processes use the same `--state-path` and are built from a version that supports the lock.
+
+For online compaction apply mode, make sure these match the running sync daemon:
+
+- `--state-path`
+- `--s3-bucket`
+- `--s3-prefix`
+- `--s3-endpoint` / region configuration
+
+If maintenance is pointed at a different state DB, bucket, or prefix, it may not coordinate with the active sync process or may operate on the wrong table location. A future read-only sync status endpoint will make this validation explicit.
+
+Compaction writes replacement files before publishing new Iceberg metadata. If validation fails before commit, uncommitted outputs may remain as orphan candidates. If a metadata publish result is uncertain, Streambed does not delete newly written files immediately because they may have become referenced by a committed snapshot.


### PR DESCRIPTION
## Summary
- document `streambed maintenance` snapshot expiration/orphan dry-run behavior
- document `streambed maintenance compact` small-file compaction usage and safety notes
- mention `--target-file-size-mb` in README

## Validation
- go test ./...

Follow-up docs for #49.