### PR TITLE
Skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- add `paths-ignore` for Markdown files and `docs/**` on `push` and `pull_request`
- prevents CI from running for README/docs-only updates
- scheduled and manual workflow runs are unaffected

## Validation

- inspected `origin/main` and confirmed the docs-only skip was not included in #52
- cherry-picked the existing workflow change onto a new branch
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
