### PR TITLE
test: ack and storage failpoints

### DIFF
--- a/internal/failpoint/failpoint.go
+++ b/internal/failpoint/failpoint.go
@@ -1,0 +1,131 @@
+package failpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+var ErrInjected = errors.New("failpoint injected failure")
+
+type action struct {
+	err      error
+	blockCh  chan struct{}
+	hitCh    chan struct{}
+	hitOnce  sync.Once
+	released bool
+}
+
+type Handle struct {
+	name string
+}
+
+var registry = struct {
+	sync.Mutex
+	actions map[string]*action
+}{actions: map[string]*action{}}
+
+func EnableError(name string, err error) {
+	if err == nil {
+		err = ErrInjected
+	}
+	registry.Lock()
+	defer registry.Unlock()
+	registry.actions[name] = &action{err: err, hitCh: make(chan struct{})}
+}
+
+func EnableBlock(name string) *Handle {
+	registry.Lock()
+	defer registry.Unlock()
+	registry.actions[name] = &action{blockCh: make(chan struct{}), hitCh: make(chan struct{})}
+	return &Handle{name: name}
+}
+
+func Disable(name string) {
+	registry.Lock()
+	defer registry.Unlock()
+	if a := registry.actions[name]; a != nil && a.blockCh != nil && !a.released {
+		close(a.blockCh)
+	}
+	delete(registry.actions, name)
+}
+
+func DisableAll() {
+	registry.Lock()
+	defer registry.Unlock()
+	for _, a := range registry.actions {
+		if a.blockCh != nil && !a.released {
+			close(a.blockCh)
+		}
+	}
+	registry.actions = map[string]*action{}
+}
+
+func (h *Handle) Release() {
+	if h == nil {
+		return
+	}
+	registry.Lock()
+	defer registry.Unlock()
+	a := registry.actions[h.name]
+	if a == nil || a.blockCh == nil || a.released {
+		return
+	}
+	a.released = true
+	close(a.blockCh)
+}
+
+func (h *Handle) WaitHit(ctx context.Context) error {
+	if h == nil {
+		return nil
+	}
+	registry.Lock()
+	a := registry.actions[h.name]
+	registry.Unlock()
+	if a == nil {
+		return fmt.Errorf("failpoint %q is not enabled", h.name)
+	}
+	select {
+	case <-a.hitCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func Check(ctx context.Context, name string) error {
+	registry.Lock()
+	a := registry.actions[name]
+	registry.Unlock()
+
+	if a == nil && envEnabled(name) {
+		return fmt.Errorf("%w: %s", ErrInjected, name)
+	}
+	if a == nil {
+		return nil
+	}
+	a.hitOnce.Do(func() { close(a.hitCh) })
+	if a.blockCh != nil {
+		select {
+		case <-a.blockCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if a.err != nil {
+		return fmt.Errorf("%w: %s", a.err, name)
+	}
+	return nil
+}
+
+func envEnabled(name string) bool {
+	for _, raw := range strings.Split(os.Getenv("STREAMBED_FAILPOINTS"), ",") {
+		if strings.TrimSpace(raw) == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/failpoint/failpoint_test.go
+++ b/internal/failpoint/failpoint_test.go
@@ -1,0 +1,54 @@
+package failpoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDisabledFailpointIsNoop(t *testing.T) {
+	DisableAll()
+	if err := Check(context.Background(), "missing"); err != nil {
+		t.Fatalf("disabled failpoint returned error: %v", err)
+	}
+}
+
+func TestErrorFailpoint(t *testing.T) {
+	DisableAll()
+	t.Cleanup(DisableAll)
+	want := errors.New("boom")
+	EnableError("before_parquet_write", want)
+	if err := Check(context.Background(), "before_parquet_write"); !errors.Is(err, want) {
+		t.Fatalf("Check error = %v, want %v", err, want)
+	}
+}
+
+func TestBlockingFailpointCanBeReleased(t *testing.T) {
+	DisableAll()
+	t.Cleanup(DisableAll)
+	h := EnableBlock("before_standby_status_update")
+	done := make(chan error, 1)
+	go func() { done <- Check(context.Background(), "before_standby_status_update") }()
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := h.WaitHit(waitCtx); err != nil {
+		t.Fatalf("wait hit: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("failpoint returned before release: %v", err)
+	default:
+	}
+	h.Release()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Check after release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("failpoint did not release")
+	}
+}

--- a/internal/iceberg/catalog.go
+++ b/internal/iceberg/catalog.go
@@ -13,6 +13,7 @@ import (
 
 	ice "github.com/apache/iceberg-go"
 	"github.com/google/uuid"
+	"github.com/viggy28/streambed/internal/failpoint"
 	"github.com/viggy28/streambed/internal/storage"
 	"github.com/viggy28/streambed/internal/wal"
 )
@@ -644,6 +645,9 @@ func (c *Catalog) CommitChangesetFiles(
 			entries = append(entries, dataManifestEntry{FilePath: c.dataFileURI(basePath, f), File: f})
 		}
 		if len(entries) > 0 {
+			if err := failpoint.Check(ctx, "before_manifest_write"); err != nil {
+				return err
+			}
 			manifestBytes, mf, err := writeDataManifestAvro(manifestS3Path, iceSchema, snapID, seqNum, entries)
 			if err != nil {
 				return fmt.Errorf("write data manifest avro: %w", err)
@@ -761,10 +765,16 @@ func (c *Catalog) CommitChangesetFiles(
 		return fmt.Errorf("marshal new metadata: %w", err)
 	}
 	newMetaKey := path.Join(basePath, "metadata", fmt.Sprintf("v%d.metadata.json", newVersion))
+	if err := failpoint.Check(ctx, "before_metadata_commit"); err != nil {
+		return err
+	}
 	if err := c.storage.PutObject(ctx, newMetaKey, newMetadataJSON, "application/json"); err != nil {
 		return err
 	}
-	return c.storage.PutObject(ctx, hintKey, []byte(strconv.Itoa(newVersion)), "text/plain")
+	if err := c.storage.PutObject(ctx, hintKey, []byte(strconv.Itoa(newVersion)), "text/plain"); err != nil {
+		return err
+	}
+	return failpoint.Check(ctx, "after_metadata_commit_before_state_or_ack")
 }
 
 func (c *Catalog) dataFileURI(basePath string, f DataFile) string {
@@ -832,10 +842,16 @@ func (c *Catalog) commitEmptyTable(ctx context.Context, schema, table, flushLSN 
 	}
 
 	newMetaKey := path.Join(basePath, "metadata", fmt.Sprintf("v%d.metadata.json", newVersion))
+	if err := failpoint.Check(ctx, "before_metadata_commit"); err != nil {
+		return err
+	}
 	if err := c.storage.PutObject(ctx, newMetaKey, newMetadataJSON, "application/json"); err != nil {
 		return err
 	}
-	return c.storage.PutObject(ctx, hintKey, []byte(strconv.Itoa(newVersion)), "text/plain")
+	if err := c.storage.PutObject(ctx, hintKey, []byte(strconv.Itoa(newVersion)), "text/plain"); err != nil {
+		return err
+	}
+	return failpoint.Check(ctx, "after_metadata_commit_before_state_or_ack")
 }
 
 // GetSnapshotFlushLSN reads the streambed.last_flush_lsn from the current

--- a/internal/iceberg/writer.go
+++ b/internal/iceberg/writer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pglogrepl"
+	"github.com/viggy28/streambed/internal/failpoint"
 	pqbuilder "github.com/viggy28/streambed/internal/parquet"
 	"github.com/viggy28/streambed/internal/state"
 	"github.com/viggy28/streambed/internal/storage"
@@ -710,8 +711,14 @@ func (w *Writer) writeDataFiles(ctx context.Context, key string, buf *tableBuffe
 		}
 		name := fmt.Sprintf("data/%s.parquet", uuid.New().String())
 		s3Key := fmt.Sprintf("%s/%s/%s/%s", w.catalog.prefix, buf.Schema, buf.Table, name)
+		if err := failpoint.Check(ctx, "before_parquet_write"); err != nil {
+			return nil, err
+		}
 		if err := w.storage.PutObject(ctx, s3Key, parquetData, "application/octet-stream"); err != nil {
 			return nil, fmt.Errorf("upload parquet for %s: %w", key, err)
+		}
+		if err := failpoint.Check(ctx, "after_parquet_write_before_metadata_commit"); err != nil {
+			return nil, err
 		}
 		lower, upper := computeKeyBounds(buf, chunk)
 		files = append(files, DataFile{Path: name, RowCount: int64(len(chunk)), FileSize: int64(len(parquetData)), LowerBounds: lower, UpperBounds: upper})

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/viggy28/streambed/internal/failpoint"
 	"github.com/viggy28/streambed/internal/iceberg"
 	"github.com/viggy28/streambed/internal/state"
 	"github.com/viggy28/streambed/internal/wal"
@@ -415,6 +416,9 @@ func computeAck(receivedLSN, pendingMinLSN pglogrepl.LSN) pglogrepl.LSN {
 func (p *Pipeline) sendStandby(ctx context.Context, receivedLSN pglogrepl.LSN) error {
 	pendingMinLSN := p.writer.ComputePendingMinLSN()
 	ack := computeAck(receivedLSN, pendingMinLSN)
+	if err := failpoint.Check(ctx, "before_standby_status_update"); err != nil {
+		return err
+	}
 	err := pglogrepl.SendStandbyStatusUpdate(ctx, p.conn,
 		pglogrepl.StandbyStatusUpdate{
 			WALWritePosition: ack,

--- a/test/integration/ack_object_store_failpoint_test.go
+++ b/test/integration/ack_object_store_failpoint_test.go
@@ -1,0 +1,256 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/viggy28/streambed/internal/failpoint"
+)
+
+func TestAckDoesNotAdvancePastPendingBuffer(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+	prepareAckFailureTest(t)
+	setupTestTable(t)
+	createSlotAndPublication(t)
+
+	statePath := t.TempDir() + "/state.db"
+	insertRows(t, 10)
+	walEnd := currentWALInsertLSN(t)
+
+	fp := failpoint.EnableBlock("before_standby_status_update")
+	pid, done, cancel := startSyncPipelineForDisconnectTest(t, ctx, statePath, 1000, time.Hour)
+	defer cancel()
+	defer terminateIfRunning(t, pid)
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 20*time.Second)
+	defer waitCancel()
+	if err := fp.WaitHit(waitCtx); err != nil {
+		t.Fatalf("wait for standby failpoint: %v", err)
+	}
+	fp.Release()
+	waitForSlotLSN(t, func(lsn pglogrepl.LSN) bool { return lsn > 0 }, 10*time.Second)
+
+	pendingAck := getSlotConfirmedFlushLSN(t)
+	if pendingAck >= walEnd {
+		t.Fatalf("slot ack advanced past pending rows: confirmed=%s wal_end=%s", pendingAck, walEnd)
+	}
+
+	cancel()
+	waitPipelineDone(t, done, 20*time.Second, true)
+	runSync(t, ctx, 12*time.Second, statePath)
+
+	finalAck := getSlotConfirmedFlushLSN(t)
+	if finalAck <= pendingAck {
+		t.Fatalf("slot ack did not advance after durable flush: before=%s after=%s", pendingAck, finalAck)
+	}
+	if got := countNamedTableSnapshotRows(t, "public", "test_events"); got != 10 {
+		t.Fatalf("Iceberg rows = %d, want 10", got)
+	}
+}
+
+func TestParquetWriteFailureDoesNotAck(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+	prepareAckFailureTest(t)
+	setupTestTable(t)
+	createSlotAndPublication(t)
+	statePath := t.TempDir() + "/state.db"
+
+	insertRows(t, 10)
+	walEnd := currentWALInsertLSN(t)
+	failpoint.EnableError("before_parquet_write", fmt.Errorf("forced parquet write failure"))
+
+	_, done, cancel := startSyncPipelineForDisconnectTest(t, ctx, statePath, 5, time.Hour)
+	defer cancel()
+	err := waitPipelineDone(t, done, 20*time.Second, false)
+	if err == nil || !strings.Contains(err.Error(), "forced parquet write failure") {
+		t.Fatalf("pipeline error = %v, want forced parquet write failure", err)
+	}
+	assertAckHeldBefore(t, walEnd)
+	if got := countNamedTableSnapshotRows(t, "public", "test_events"); got != 0 {
+		t.Fatalf("Iceberg rows after failed parquet write = %d, want 0", got)
+	}
+
+	failpoint.DisableAll()
+	runSync(t, ctx, 12*time.Second, statePath)
+	assertTestEventsMatch(t, 10)
+}
+
+func TestIcebergMetadataCommitFailureDoesNotAck(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+	prepareAckFailureTest(t)
+	setupTestTable(t)
+	createSlotAndPublication(t)
+	statePath := t.TempDir() + "/state.db"
+
+	insertRows(t, 10)
+	walEnd := currentWALInsertLSN(t)
+	failpoint.EnableError("before_metadata_commit", fmt.Errorf("forced metadata commit failure"))
+
+	_, done, cancel := startSyncPipelineForDisconnectTest(t, ctx, statePath, 5, time.Hour)
+	defer cancel()
+	err := waitPipelineDone(t, done, 20*time.Second, false)
+	if err == nil || !strings.Contains(err.Error(), "forced metadata commit failure") {
+		t.Fatalf("pipeline error = %v, want forced metadata commit failure", err)
+	}
+	assertAckHeldBefore(t, walEnd)
+	if got := countNamedTableSnapshotRows(t, "public", "test_events"); got != 0 {
+		t.Fatalf("Iceberg rows after failed metadata commit = %d, want 0", got)
+	}
+
+	failpoint.DisableAll()
+	runSync(t, ctx, 12*time.Second, statePath)
+	assertTestEventsMatch(t, 10)
+}
+
+func TestCrashAfterIcebergCommitBeforeAckReplaysIdempotently(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+	prepareAckFailureTest(t)
+	setupTestTable(t)
+	createSlotAndPublication(t)
+	statePath := t.TempDir() + "/state.db"
+
+	insertRows(t, 10)
+	walEnd := currentWALInsertLSN(t)
+	failpoint.EnableError("after_metadata_commit_before_state_or_ack", fmt.Errorf("forced post-commit pre-ack crash"))
+
+	_, done, cancel := startSyncPipelineForDisconnectTest(t, ctx, statePath, 5, time.Hour)
+	defer cancel()
+	err := waitPipelineDone(t, done, 20*time.Second, false)
+	if err == nil || !strings.Contains(err.Error(), "forced post-commit pre-ack crash") {
+		t.Fatalf("pipeline error = %v, want forced post-commit pre-ack crash", err)
+	}
+	assertAckHeldBefore(t, walEnd)
+	if got := countNamedTableSnapshotRows(t, "public", "test_events"); got != 5 {
+		t.Fatalf("Iceberg rows after committed first flush = %d, want 5", got)
+	}
+
+	failpoint.DisableAll()
+	runSync(t, ctx, 15*time.Second, statePath)
+	assertTestEventsMatch(t, 10)
+}
+
+func TestTemporaryObjectStoreOutageHoldsAckAndRecovers(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+	prepareAckFailureTest(t)
+	setupTestTable(t)
+	createSlotAndPublication(t)
+	statePath := t.TempDir() + "/state.db"
+
+	insertRows(t, 10)
+	walEnd := currentWALInsertLSN(t)
+	fp := failpoint.EnableBlock("before_parquet_write")
+
+	_, done, cancel := startSyncPipelineForDisconnectTest(t, ctx, statePath, 5, time.Hour)
+	defer cancel()
+	waitCtx, waitCancel := context.WithTimeout(ctx, 20*time.Second)
+	defer waitCancel()
+	if err := fp.WaitHit(waitCtx); err != nil {
+		t.Fatalf("wait for parquet write failpoint: %v", err)
+	}
+	assertAckHeldBefore(t, walEnd)
+	fp.Release()
+
+	waitForNamedTableSnapshotRowsAtLeast(t, "public", "test_events", 10, 20*time.Second)
+	failpoint.DisableAll()
+	cancel()
+	waitPipelineDone(t, done, 20*time.Second, true)
+	runSync(t, ctx, 12*time.Second, statePath)
+	assertTestEventsMatch(t, 10)
+}
+
+func prepareAckFailureTest(t *testing.T) {
+	t.Helper()
+	failpoint.DisableAll()
+	t.Cleanup(failpoint.DisableAll)
+	cleanup(t)
+	t.Cleanup(func() { cleanup(t) })
+	clearS3Prefix(t)
+}
+
+func currentWALInsertLSN(t *testing.T) pglogrepl.LSN {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := pgconn.Connect(ctx, pgConnStr())
+	if err != nil {
+		t.Fatalf("connect for current WAL LSN: %v", err)
+	}
+	defer conn.Close(ctx)
+	results, err := conn.Exec(ctx, "SELECT pg_current_wal_insert_lsn()").ReadAll()
+	if err != nil {
+		t.Fatalf("query current WAL LSN: %v", err)
+	}
+	lsn, err := pglogrepl.ParseLSN(string(results[0].Rows[0][0]))
+	if err != nil {
+		t.Fatalf("parse current WAL LSN: %v", err)
+	}
+	return lsn
+}
+
+func waitPipelineDone(t *testing.T, done <-chan error, timeout time.Duration, allowContext bool) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		if allowContext {
+			return err
+		}
+		return err
+	case <-time.After(timeout):
+		t.Fatalf("pipeline did not stop within %s", timeout)
+		return nil
+	}
+}
+
+func assertAckHeldBefore(t *testing.T, walEnd pglogrepl.LSN) {
+	t.Helper()
+	ack := getSlotConfirmedFlushLSN(t)
+	if ack >= walEnd {
+		t.Fatalf("slot ack advanced past non-durable WAL: confirmed=%s wal_end=%s", ack, walEnd)
+	}
+}
+
+func waitForSlotLSN(t *testing.T, pred func(pglogrepl.LSN) bool, timeout time.Duration) pglogrepl.LSN {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lsn pglogrepl.LSN
+	for time.Now().Before(deadline) {
+		lsn = getSlotConfirmedFlushLSN(t)
+		if pred(lsn) {
+			return lsn
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for slot LSN predicate; last=%s", lsn)
+	return 0
+}
+
+func assertTestEventsMatch(t *testing.T, want int64) {
+	t.Helper()
+	if pgCount := pgRowCount(t, "test_events"); pgCount != want {
+		t.Fatalf("Postgres rows = %d, want %d", pgCount, want)
+	}
+	if got := countNamedTableSnapshotRows(t, "public", "test_events"); got != want {
+		t.Fatalf("Iceberg rows = %d, want %d", got, want)
+	}
+	duckDB := newTestDuckDB(t)
+	assertPgIcebergMatch(t, duckDB, "public", "test_events", []string{"id"}, []string{"id", "name"})
+}
+
+func terminateIfRunning(t *testing.T, pid uint32) {
+	t.Helper()
+	if pid == 0 {
+		return
+	}
+	_ = pid // process exits through context cancellation in normal test flow.
+}


### PR DESCRIPTION
Problem: ack/durability boundaries lacked deterministic failure coverage.

Solved: adds failpoints plus integration tests for pending-buffer ack, Parquet failures, metadata failures, post-commit/pre-ack replay, and temporary storage outage recovery.

Changes: adds internal/failpoint, hooks writer/catalog/pipeline durability points, and adds ack/object-store integration tests.