### PR TITLE
Update website maintenance docs

### DIFF
--- a/site/content/docs/architecture.md
+++ b/site/content/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Architecture
-weight: 4
-prev: /docs/configuration
+weight: 5
+prev: /docs/maintenance
 ---
 
 ## Overview

--- a/site/content/docs/commands.md
+++ b/site/content/docs/commands.md
@@ -5,7 +5,7 @@ next: /docs/configuration
 prev: /docs/getting-started
 ---
 
-Streambed provides four commands via the CLI.
+Streambed provides operational commands for syncing, querying, backfilling, cleanup, and maintenance.
 
 ## `streambed sync`
 
@@ -53,3 +53,33 @@ Deletes S3 objects and local state for a table.
 ```
 
 Run this before `resync` to start fresh, or when decommissioning a table from Streambed.
+
+## `streambed maintenance`
+
+Expires old Iceberg snapshots and can dry-run orphan planning.
+
+```bash
+./streambed maintenance \
+  --table=public.users \
+  --retain-last=1 \
+  --dry-run
+```
+
+Use apply mode with `--dry-run=false --force` after reviewing the plan. Orphan deletion is currently dry-run only.
+
+## `streambed maintenance compact`
+
+Compacts many small active Parquet data files into fewer target-sized files.
+
+```bash
+./streambed maintenance compact \
+  --table=public.users \
+  --target-file-size-mb=128 \
+  --small-file-threshold-mb=32 \
+  --max-input-files=1000 \
+  --dry-run
+```
+
+Apply with `--dry-run=false --force`. Online compaction coordinates with `streambed sync` through the SQLite state DB, so the maintenance process must use the same `--state-path`, S3 bucket, and S3 prefix as the running sync daemon.
+
+See [Maintenance](/docs/maintenance/) for details and safety notes.

--- a/site/content/docs/configuration.md
+++ b/site/content/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 weight: 3
-next: /docs/architecture
+next: /docs/maintenance
 prev: /docs/commands
 ---
 

--- a/site/content/docs/maintenance.md
+++ b/site/content/docs/maintenance.md
@@ -1,0 +1,71 @@
+---
+title: Maintenance
+weight: 4
+prev: /docs/configuration
+next: /docs/architecture
+---
+
+Streambed includes maintenance commands for Iceberg table metadata and file layout.
+
+## Snapshot expiration
+
+```bash
+streambed maintenance \
+  --table public.users \
+  --retain-last 1 \
+  --dry-run
+```
+
+Apply snapshot expiration:
+
+```bash
+streambed maintenance \
+  --table public.users \
+  --retain-last 1 \
+  --dry-run=false \
+  --force
+```
+
+Snapshot expiration removes old snapshot references from Iceberg metadata. It does not immediately delete all old data files unless they are part of the expiration plan. Orphan deletion is intentionally dry-run only until safer age and locking support is added.
+
+## Small-file compaction
+
+Frequent CDC flushes can create many small Parquet files. Small-file compaction rewrites clean active data files into fewer target-sized files:
+
+```bash
+streambed maintenance compact \
+  --table public.users \
+  --target-file-size-mb 128 \
+  --small-file-threshold-mb 32 \
+  --max-input-files 1000 \
+  --dry-run
+```
+
+Apply compaction:
+
+```bash
+streambed maintenance compact \
+  --table public.users \
+  --target-file-size-mb 128 \
+  --small-file-threshold-mb 32 \
+  --max-input-files 1000 \
+  --dry-run=false \
+  --force
+```
+
+Compaction currently handles clean active data files only. If a table has active MOR equality delete files, compaction skips the table; MOR delete-file compaction is tracked separately.
+
+## Safety notes
+
+Online maintenance uses a SQLite-backed table commit lock. This coordinates with `streambed sync` only when both processes use the same `--state-path` and both binaries include lock support.
+
+For online compaction apply mode, make sure these match the running sync daemon:
+
+- `--state-path`
+- `--s3-bucket`
+- `--s3-prefix`
+- `--s3-endpoint` / region configuration
+
+If maintenance is pointed at a different state DB, bucket, or prefix, it may not coordinate with the active sync process or may operate on the wrong table location. A future read-only sync status endpoint will make this validation explicit.
+
+Compaction writes replacement files before publishing new Iceberg metadata. If validation fails before commit, uncommitted outputs may remain as orphan candidates. If a metadata publish result is uncertain, Streambed does not delete newly written files immediately because they may have become referenced by a committed snapshot.


### PR DESCRIPTION
## Summary
- add Maintenance page to website docs
- update Commands page with `streambed maintenance` and `streambed maintenance compact`
- wire docs navigation without removing existing content

## Validation
- `cd site && hugo --minify`

Follow-up to #59. Related to #63.