### PR TITLE
Fix append snapshot total-records summaries

### DIFF
--- a/internal/iceberg/catalog.go
+++ b/internal/iceberg/catalog.go
@@ -709,6 +709,7 @@ func (c *Catalog) CommitChangesetFiles(
 	}
 
 	newVersion := currentVersion + 1
+	previousTotal, previousTotalExact := currentSnapshotTotalRecords(metadata)
 	metadata.LastSequenceNumber = seqNum
 	metadata.LastUpdatedMS = time.Now().UnixMilli()
 	metadata.CurrentSnapshotID = snapID
@@ -748,10 +749,8 @@ func (c *Catalog) CommitChangesetFiles(
 	}
 	if replace {
 		summary["total-records"] = strconv.FormatInt(totalRows, 10)
-	} else if len(eqDeleteFiles) == 0 && !hasEqualityDeletes(metadata.Snapshots) {
-		if currentTotal, exact := currentSnapshotTotalRecords(metadata); exact {
-			summary["total-records"] = strconv.FormatInt(currentTotal+addedRows, 10)
-		}
+	} else if len(eqDeleteFiles) == 0 && !hasEqualityDeletes(metadata.Snapshots) && previousTotalExact {
+		summary["total-records"] = strconv.FormatInt(previousTotal+addedRows, 10)
 	}
 
 	newSnapshot := snapshot{SnapshotID: snapID, SequenceNumber: seqNum, TimestampMS: time.Now().UnixMilli(), ManifestList: fmt.Sprintf("s3://%s/%s", c.bucket, manifestListKey), Summary: summary}

--- a/internal/iceberg/catalog_test.go
+++ b/internal/iceberg/catalog_test.go
@@ -129,6 +129,41 @@ func TestCurrentSnapshotTotalRecordsUnknown(t *testing.T) {
 	}
 }
 
+func TestAppendSnapshotsPublishExactTotalRecords(t *testing.T) {
+	ctx := context.Background()
+	mem := storage.NewMemS3Client("test-bucket")
+	catalog := NewCatalog(mem, "test-bucket", "test")
+
+	if _, err := catalog.CreateTable(ctx, "public", "events", []ColumnDef{{Name: "id", OID: 23}}); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if err := catalog.CommitSnapshot(ctx, "public", "events", DataFile{Path: "data/1.parquet", RowCount: 10, FileSize: 100}, "0/10"); err != nil {
+		t.Fatalf("commit first snapshot: %v", err)
+	}
+	if err := catalog.CommitSnapshot(ctx, "public", "events", DataFile{Path: "data/2.parquet", RowCount: 10, FileSize: 100}, "0/20"); err != nil {
+		t.Fatalf("commit second snapshot: %v", err)
+	}
+
+	hint, err := mem.GetObject(ctx, "test/public/events/metadata/version-hint.text")
+	if err != nil {
+		t.Fatalf("read version hint: %v", err)
+	}
+	metadataJSON, err := mem.GetObject(ctx, "test/public/events/metadata/v"+string(hint)+".metadata.json")
+	if err != nil {
+		t.Fatalf("read latest metadata: %v", err)
+	}
+	var metadata tableMetadata
+	if err := json.Unmarshal(metadataJSON, &metadata); err != nil {
+		t.Fatalf("parse metadata: %v", err)
+	}
+	if got := metadata.Snapshots[0].Summary["total-records"]; got != "10" {
+		t.Fatalf("first snapshot total-records = %q, want 10", got)
+	}
+	if got := metadata.Snapshots[1].Summary["total-records"]; got != "20" {
+		t.Fatalf("second snapshot total-records = %q, want 20", got)
+	}
+}
+
 func TestEqualityDeleteHistoryOmitsUnknownTotalRecords(t *testing.T) {
 	snapshots := []snapshot{
 		{Summary: map[string]string{"added-records": "10", "total-records": "10"}},


### PR DESCRIPTION
Closes #73.

## Summary

- compute the previous snapshot's exact row total before mutating `CurrentSnapshotID` to the new snapshot ID
- use that preserved previous total when publishing append-only `total-records`
- add a unit test that commits two append snapshots and verifies totals `10` and `20`

## Root cause

`CommitChangesetFiles` updated `metadata.CurrentSnapshotID` to the new snapshot ID before calculating the append snapshot summary. At that point the new snapshot had not yet been appended to `metadata.Snapshots`, so `currentSnapshotTotalRecords(metadata)` looked for the new snapshot and returned `exact=false`. That caused append snapshots to omit `total-records`, which broke `TestFlushThresholdCreatesExpectedParquetAndMetadata`.

## Validation

- `go test ./internal/iceberg ./internal/... ./config/...`
- `docker compose -f test/integration/docker-compose.yml up -d postgres minio --wait && docker compose -f test/integration/docker-compose.yml up createbucket && go test -tags integration -v -run '^TestFlushThresholdCreatesExpectedParquetAndMetadata$' -count=1 -timeout 2m ./test/integration`
