### PR TITLE
Add DuckLake target support

### DIFF
--- a/cmd/streambed/main.go
+++ b/cmd/streambed/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/viggy28/streambed/config"
+	"github.com/viggy28/streambed/internal/ducklake"
 	"github.com/viggy28/streambed/internal/iceberg"
 	"github.com/viggy28/streambed/internal/pipeline"
 	"github.com/viggy28/streambed/internal/resync"
@@ -50,6 +51,9 @@ func main() {
 	syncCmd.Flags().StringVar(&cfg.S3Endpoint, "s3-endpoint", cfg.S3Endpoint, "Custom S3 endpoint (MinIO)")
 	syncCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
 	syncCmd.Flags().StringVar(&cfg.StatePath, "state-path", cfg.StatePath, "SQLite state file path")
+	syncCmd.Flags().StringVar(&cfg.TargetFormat, "target-format", cfg.TargetFormat, "Lakehouse target format: iceberg or ducklake")
+	syncCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake SQLite catalog path")
+	syncCmd.Flags().StringVar(&cfg.DuckLakeDataPath, "ducklake-data-path", cfg.DuckLakeDataPath, "DuckLake data path (defaults to s3://bucket/prefix/ducklake/)")
 	syncCmd.Flags().StringVar(&cfg.SlotName, "slot-name", cfg.SlotName, "Replication slot name")
 	syncCmd.Flags().IntVar(&cfg.FlushRows, "flush-rows", cfg.FlushRows, "Row buffer flush threshold")
 	syncCmd.Flags().DurationVar(&cfg.FlushInterval, "flush-interval", cfg.FlushInterval, "Time-based flush interval")
@@ -70,6 +74,9 @@ func main() {
 	queryCmd.Flags().StringVar(&cfg.S3Prefix, "s3-prefix", cfg.S3Prefix, "S3 key prefix")
 	queryCmd.Flags().StringVar(&cfg.S3Endpoint, "s3-endpoint", cfg.S3Endpoint, "Custom S3 endpoint (MinIO)")
 	queryCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
+	queryCmd.Flags().StringVar(&cfg.TargetFormat, "target-format", cfg.TargetFormat, "Lakehouse target format: iceberg or ducklake")
+	queryCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake SQLite catalog path")
+	queryCmd.Flags().StringVar(&cfg.DuckLakeDataPath, "ducklake-data-path", cfg.DuckLakeDataPath, "DuckLake data path (defaults to s3://bucket/prefix/ducklake/)")
 	queryCmd.Flags().StringVar(&cfg.QueryAddr, "listen-addr", cfg.QueryAddr, "Listen address for query server")
 	queryCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
 
@@ -172,6 +179,9 @@ snapshot LSN are silently discarded for this table to avoid duplicates.`,
 	resyncCmd.Flags().StringVar(&cfg.S3Endpoint, "s3-endpoint", cfg.S3Endpoint, "Custom S3 endpoint (MinIO)")
 	resyncCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
 	resyncCmd.Flags().StringVar(&cfg.StatePath, "state-path", cfg.StatePath, "SQLite state file path")
+	resyncCmd.Flags().StringVar(&cfg.TargetFormat, "target-format", cfg.TargetFormat, "Lakehouse target format: iceberg or ducklake")
+	resyncCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake SQLite catalog path")
+	resyncCmd.Flags().StringVar(&cfg.DuckLakeDataPath, "ducklake-data-path", cfg.DuckLakeDataPath, "DuckLake data path (defaults to s3://bucket/prefix/ducklake/)")
 	resyncCmd.Flags().IntVar(&cfg.FlushRows, "flush-rows", cfg.FlushRows, "Rows per parquet file / Iceberg snapshot")
 	resyncCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
 
@@ -200,6 +210,12 @@ func runSync(cmd *cobra.Command, args []string) error {
 			cfg.S3Region = f.Value.String()
 		case "state-path":
 			cfg.StatePath = f.Value.String()
+		case "target-format":
+			cfg.TargetFormat = strings.ToLower(f.Value.String())
+		case "ducklake-catalog":
+			cfg.DuckLakeCatalog = f.Value.String()
+		case "ducklake-data-path":
+			cfg.DuckLakeDataPath = f.Value.String()
 		case "slot-name":
 			cfg.SlotName = f.Value.String()
 		case "flush-rows":
@@ -232,6 +248,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		"bucket", cfg.S3Bucket,
 		"prefix", cfg.S3Prefix,
 		"slot", cfg.SlotName,
+		"target_format", cfg.TargetFormat,
 		"flush_rows", cfg.FlushRows,
 		"flush_interval", cfg.FlushInterval,
 		"target_file_size_mb", cfg.TargetFileSizeMB,
@@ -261,26 +278,58 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 	defer stateStore.Close()
 
-	// Initialize S3 client and validate the selected mutation strategy before
-	// starting query or replication services. This prevents a COW process from
-	// appearing healthy and failing only when its first UPDATE/DELETE arrives.
+	// Initialize S3 client and selected lakehouse target.
 	s3Client, err := storage.NewS3Client(ctx, cfg.S3Bucket, cfg.S3Region, cfg.S3Endpoint)
 	if err != nil {
 		return fmt.Errorf("create S3 client: %w", err)
 	}
-	catalog := iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
-	if err := catalog.ValidateMutationMode(ctx, iceberg.MutationMode(cfg.MutationMode)); err != nil {
-		return err
+	var catalog *iceberg.Catalog
+	var writer pipeline.Writer
+	var duckWriter *ducklake.Writer
+	makeWriter := func() (pipeline.Writer, error) {
+		if cfg.TargetFormat == "ducklake" {
+			w, err := ducklake.NewWriter(ctx, ducklake.Config{
+				CatalogPath: cfg.DuckLakeCatalog,
+				DataPath:    cfg.EffectiveDuckLakeDataPath(),
+				S3Endpoint:  cfg.S3Endpoint,
+				S3Region:    cfg.S3Region,
+			}, stateStore, cfg.FlushRows, cfg.FlushInterval, logger)
+			if err != nil {
+				return nil, err
+			}
+			duckWriter = w
+			return w, nil
+		}
+		return iceberg.NewWriter(catalog, s3Client, stateStore, cfg.SlotName,
+			cfg.FlushRows, cfg.FlushInterval, logger,
+			iceberg.WithMutationMode(iceberg.MutationMode(cfg.MutationMode)),
+			iceberg.WithTargetFileSizeBytes(int64(cfg.TargetFileSizeMB)*1024*1024)), nil
+	}
+	if cfg.TargetFormat == "iceberg" {
+		catalog = iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
+		if err := catalog.ValidateMutationMode(ctx, iceberg.MutationMode(cfg.MutationMode)); err != nil {
+			return err
+		}
+	}
+	writer, err = makeWriter()
+	if err != nil {
+		return fmt.Errorf("create %s writer: %w", cfg.TargetFormat, err)
+	}
+	if duckWriter != nil {
+		defer duckWriter.Close()
 	}
 
 	// Start query server if --query-addr is set
 	if cfg.QueryAddr != "" {
 		querySrv, err := server.NewServer(server.ServerConfig{
-			ListenAddr: cfg.QueryAddr,
-			S3Bucket:   cfg.S3Bucket,
-			S3Prefix:   cfg.S3Prefix,
-			S3Endpoint: cfg.S3Endpoint,
-			S3Region:   cfg.S3Region,
+			ListenAddr:       cfg.QueryAddr,
+			S3Bucket:         cfg.S3Bucket,
+			S3Prefix:         cfg.S3Prefix,
+			S3Endpoint:       cfg.S3Endpoint,
+			S3Region:         cfg.S3Region,
+			TargetFormat:     cfg.TargetFormat,
+			DuckLakeCatalog:  cfg.DuckLakeCatalog,
+			DuckLakeDataPath: cfg.EffectiveDuckLakeDataPath(),
 		}, s3Client, logger)
 		if err != nil {
 			return fmt.Errorf("create query server: %w", err)
@@ -331,7 +380,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("setup replication slot: %w", err)
 	}
 
-	// Read per-table flush LSNs from Iceberg (the sole source of truth).
+	// Read per-table flush LSNs from the lakehouse target (the sole source of truth).
 	// These are used for dedup on restart and to determine startLSN.
 	tableFlushLSN := make(map[string]pglogrepl.LSN)
 	registeredTables, err := stateStore.GetRegisteredTables()
@@ -339,16 +388,9 @@ func runSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get registered tables: %w", err)
 	}
 	for _, t := range registeredTables {
-		exists, err := catalog.TableExists(ctx, t.Schema, t.Table)
+		lsnStr, found, err := getTargetFlushLSN(ctx, cfg.TargetFormat, catalog, duckWriter, t.Schema, t.Table)
 		if err != nil {
-			return fmt.Errorf("check table %s.%s: %w", t.Schema, t.Table, err)
-		}
-		if !exists {
-			continue
-		}
-		lsnStr, found, err := catalog.GetSnapshotFlushLSN(ctx, t.Schema, t.Table)
-		if err != nil {
-			logger.Warn("cannot read Iceberg LSN, skipping",
+			logger.Warn("cannot read target LSN, skipping",
 				"table", fmt.Sprintf("%s.%s", t.Schema, t.Table),
 				"error", err,
 			)
@@ -359,39 +401,33 @@ func runSync(cmd *cobra.Command, args []string) error {
 		}
 		lsn, err := pglogrepl.ParseLSN(lsnStr)
 		if err != nil {
-			return fmt.Errorf("parse Iceberg LSN %q for %s.%s: %w", lsnStr, t.Schema, t.Table, err)
+			return fmt.Errorf("parse target LSN %q for %s.%s: %w", lsnStr, t.Schema, t.Table, err)
 		}
 		tableFlushLSN[fmt.Sprintf("%s.%s", t.Schema, t.Table)] = lsn
 	}
 
-	var minIcebergLSN pglogrepl.LSN
+	var minTargetLSN pglogrepl.LSN
 	for _, lsn := range tableFlushLSN {
-		if minIcebergLSN == 0 || lsn < minIcebergLSN {
-			minIcebergLSN = lsn
+		if minTargetLSN == 0 || lsn < minTargetLSN {
+			minTargetLSN = lsn
 		}
 	}
 
 	startLSN := slotLSN
-	if minIcebergLSN > startLSN {
-		startLSN = minIcebergLSN
-		logger.Info("resuming from Iceberg LSN", "lsn", startLSN)
-	} else if minIcebergLSN < startLSN && minIcebergLSN != 0 {
+	if minTargetLSN > startLSN {
+		startLSN = minTargetLSN
+		logger.Info("resuming from target LSN", "target_format", cfg.TargetFormat, "lsn", startLSN)
+	} else if minTargetLSN < startLSN && minTargetLSN != 0 {
 		// This is normal: cold tables retain an older flush LSN while
 		// the slot advances past them (they had no events in the gap).
 		// Log for visibility but don't block startup.
-		logger.Info("slot ahead of coldest Iceberg LSN (cold tables expected)",
+		logger.Info("slot ahead of coldest target LSN (cold tables expected)",
 			"slot_lsn", startLSN,
-			"min_iceberg_lsn", minIcebergLSN,
+			"min_target_lsn", minTargetLSN,
 		)
 	}
 
-	// Initialize writer
-	writer := iceberg.NewWriter(catalog, s3Client, stateStore, cfg.SlotName,
-		cfg.FlushRows, cfg.FlushInterval, logger,
-		iceberg.WithMutationMode(iceberg.MutationMode(cfg.MutationMode)),
-		iceberg.WithTargetFileSizeBytes(int64(cfg.TargetFileSizeMB)*1024*1024))
-
-	// Create unified pipeline (single goroutine: reads WAL + writes Iceberg)
+	// Create unified pipeline (single goroutine: reads WAL + writes target)
 	p := pipeline.New(pgConn, cfg.SlotName, pubName, startLSN, cfg.ExcludeTables,
 		logger, stateStore, tableFlushLSN, writer, cfg.FlushInterval, metaQuerier)
 
@@ -441,7 +477,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Re-read per-table flush LSNs from Iceberg (may have advanced
+		// Re-read per-table flush LSNs from the target (may have advanced
 		// from the last successful flush before the crash).
 		registeredTables, err = stateStore.GetRegisteredTables()
 		if err != nil {
@@ -449,11 +485,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		}
 		tableFlushLSN = make(map[string]pglogrepl.LSN)
 		for _, t := range registeredTables {
-			exists, err := catalog.TableExists(ctx, t.Schema, t.Table)
-			if err != nil || !exists {
-				continue
-			}
-			lsnStr, found, err := catalog.GetSnapshotFlushLSN(ctx, t.Schema, t.Table)
+			lsnStr, found, err := getTargetFlushLSN(ctx, cfg.TargetFormat, catalog, duckWriter, t.Schema, t.Table)
 			if err != nil || !found {
 				continue
 			}
@@ -478,10 +510,15 @@ func runSync(cmd *cobra.Command, args []string) error {
 		}
 
 		// Recreate writer and pipeline with fresh state.
-		writer = iceberg.NewWriter(catalog, s3Client, stateStore, cfg.SlotName,
-			cfg.FlushRows, cfg.FlushInterval, logger,
-			iceberg.WithMutationMode(iceberg.MutationMode(cfg.MutationMode)),
-			iceberg.WithTargetFileSizeBytes(int64(cfg.TargetFileSizeMB)*1024*1024))
+		if duckWriter != nil {
+			_ = duckWriter.Close()
+			duckWriter = nil
+		}
+		writer, err = makeWriter()
+		if err != nil {
+			logger.Error("reconnect: writer setup failed", "error", err)
+			continue
+		}
 		p = pipeline.New(pgConn, cfg.SlotName, pubName, startLSN, cfg.ExcludeTables,
 			logger, stateStore, tableFlushLSN, writer, cfg.FlushInterval, metaQuerier)
 
@@ -509,6 +546,12 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			cfg.S3Endpoint = f.Value.String()
 		case "s3-region":
 			cfg.S3Region = f.Value.String()
+		case "target-format":
+			cfg.TargetFormat = strings.ToLower(f.Value.String())
+		case "ducklake-catalog":
+			cfg.DuckLakeCatalog = f.Value.String()
+		case "ducklake-data-path":
+			cfg.DuckLakeDataPath = f.Value.String()
 		case "listen-addr":
 			cfg.QueryAddr = f.Value.String()
 		case "log-level":
@@ -529,6 +572,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	logger.Info("streambed query server starting",
 		"bucket", cfg.S3Bucket,
 		"prefix", cfg.S3Prefix,
+		"target_format", cfg.TargetFormat,
 		"listen_addr", cfg.QueryAddr,
 	)
 
@@ -551,11 +595,14 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 
 	querySrv, err := server.NewServer(server.ServerConfig{
-		ListenAddr: cfg.QueryAddr,
-		S3Bucket:   cfg.S3Bucket,
-		S3Prefix:   cfg.S3Prefix,
-		S3Endpoint: cfg.S3Endpoint,
-		S3Region:   cfg.S3Region,
+		ListenAddr:       cfg.QueryAddr,
+		S3Bucket:         cfg.S3Bucket,
+		S3Prefix:         cfg.S3Prefix,
+		S3Endpoint:       cfg.S3Endpoint,
+		S3Region:         cfg.S3Region,
+		TargetFormat:     cfg.TargetFormat,
+		DuckLakeCatalog:  cfg.DuckLakeCatalog,
+		DuckLakeDataPath: cfg.EffectiveDuckLakeDataPath(),
 	}, s3Client, logger)
 	if err != nil {
 		return fmt.Errorf("create query server: %w", err)
@@ -569,6 +616,23 @@ func runQuery(cmd *cobra.Command, args []string) error {
 
 	logger.Info("streambed query server stopped")
 	return nil
+}
+
+func getTargetFlushLSN(ctx context.Context, targetFormat string, catalog *iceberg.Catalog, duckWriter *ducklake.Writer, schema, table string) (string, bool, error) {
+	if targetFormat == "ducklake" {
+		if duckWriter == nil {
+			return "", false, fmt.Errorf("ducklake writer is not initialized")
+		}
+		return duckWriter.GetTableFlushLSN(ctx, schema, table)
+	}
+	exists, err := catalog.TableExists(ctx, schema, table)
+	if err != nil {
+		return "", false, err
+	}
+	if !exists {
+		return "", false, nil
+	}
+	return catalog.GetSnapshotFlushLSN(ctx, schema, table)
 }
 
 func runCleanup(cmd *cobra.Command, tables []string, dryRun, force bool) error {
@@ -871,6 +935,12 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 			cfg.S3Region = f.Value.String()
 		case "state-path":
 			cfg.StatePath = f.Value.String()
+		case "target-format":
+			cfg.TargetFormat = strings.ToLower(f.Value.String())
+		case "ducklake-catalog":
+			cfg.DuckLakeCatalog = f.Value.String()
+		case "ducklake-data-path":
+			cfg.DuckLakeDataPath = f.Value.String()
 		case "flush-rows":
 			if n, err := strconv.Atoi(f.Value.String()); err == nil && n > 0 {
 				cfg.FlushRows = n
@@ -894,6 +964,12 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 	}
 	if cfg.S3Bucket == "" {
 		return fmt.Errorf("--s3-bucket is required")
+	}
+	if cfg.TargetFormat != "iceberg" && cfg.TargetFormat != "ducklake" {
+		return fmt.Errorf("--target-format must be one of: iceberg, ducklake")
+	}
+	if cfg.TargetFormat == "ducklake" && cfg.DuckLakeCatalog == "" {
+		return fmt.Errorf("--ducklake-catalog is required when --target-format=ducklake")
 	}
 
 	logger := setupLogger(cfg.LogLevel)
@@ -922,13 +998,21 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 
 	// Confirm destructive phase up front.
 	tablePrefix := path.Join(cfg.S3Prefix, schemaName, tableName) + "/"
-	existingKeys, err := s3Client.ListPrefix(ctx, tablePrefix)
-	if err != nil {
-		return fmt.Errorf("list existing S3 objects: %w", err)
+	var existingKeys []string
+	if cfg.TargetFormat == "iceberg" {
+		existingKeys, err = s3Client.ListPrefix(ctx, tablePrefix)
+		if err != nil {
+			return fmt.Errorf("list existing S3 objects: %w", err)
+		}
 	}
 
 	fmt.Printf("\nResync %s.%s from Postgres:\n", schemaName, tableName)
-	fmt.Printf("  will delete %d S3 objects under s3://%s/%s\n", len(existingKeys), cfg.S3Bucket, tablePrefix)
+	if cfg.TargetFormat == "ducklake" {
+		fmt.Printf("  will drop DuckLake table if it exists in %s\n", cfg.DuckLakeCatalog)
+		fmt.Printf("  DuckLake data path: %s\n", cfg.EffectiveDuckLakeDataPath())
+	} else {
+		fmt.Printf("  will delete %d S3 objects under s3://%s/%s\n", len(existingKeys), cfg.S3Bucket, tablePrefix)
+	}
 	fmt.Printf("  will delete state row for %s.%s\n", schemaName, tableName)
 	fmt.Printf("  will re-COPY the table from %s\n", maskURL(cfg.SourceURL))
 	if !force {
@@ -942,8 +1026,8 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 		}
 	}
 
-	// 2. Delete existing S3 data + state row (idempotent).
-	if len(existingKeys) > 0 {
+	// 2. Delete existing target data + state row (idempotent).
+	if cfg.TargetFormat == "iceberg" && len(existingKeys) > 0 {
 		if err := s3Client.DeleteObjects(ctx, existingKeys); err != nil {
 			return fmt.Errorf("delete S3 objects: %w", err)
 		}
@@ -976,6 +1060,36 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 	defer dataConn.Close(context.Background())
 
 	// 4. Run the backfill.
+	if cfg.TargetFormat == "ducklake" {
+		writer, err := ducklake.NewWriter(ctx, ducklake.Config{
+			CatalogPath: cfg.DuckLakeCatalog,
+			DataPath:    cfg.EffectiveDuckLakeDataPath(),
+			S3Endpoint:  cfg.S3Endpoint,
+			S3Region:    cfg.S3Region,
+		}, stateStore, cfg.FlushRows, cfg.FlushInterval, logger)
+		if err != nil {
+			return fmt.Errorf("create ducklake writer: %w", err)
+		}
+		defer writer.Close()
+		stats, err := ducklake.RunResync(ctx, ducklake.ResyncOptions{
+			Schema:    schemaName,
+			Table:     tableName,
+			FlushRows: cfg.FlushRows,
+			ReplConn:  replConn,
+			DataConn:  dataConn,
+			State:     stateStore,
+			Writer:    writer,
+			Logger:    logger,
+		})
+		if err != nil {
+			return fmt.Errorf("resync %s.%s: %w", schemaName, tableName, err)
+		}
+		fmt.Printf("\nresync complete: %d rows, %d batch(es), backfill_lsn=%s\n",
+			stats.Rows, stats.Batches, stats.BackfillLSN)
+		fmt.Println("Restart `streambed sync` to resume CDC with the overlap filter active.")
+		return nil
+	}
+
 	catalog := iceberg.NewCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix)
 	stats, err := resync.Run(ctx, resync.Options{
 		Schema:    schemaName,

--- a/cmd/streambed/main.go
+++ b/cmd/streambed/main.go
@@ -52,7 +52,8 @@ func main() {
 	syncCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
 	syncCmd.Flags().StringVar(&cfg.StatePath, "state-path", cfg.StatePath, "SQLite state file path")
 	syncCmd.Flags().StringVar(&cfg.TargetFormat, "target-format", cfg.TargetFormat, "Lakehouse target format: iceberg or ducklake")
-	syncCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake SQLite catalog path")
+	syncCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake catalog path")
+	syncCmd.Flags().StringVar(&cfg.DuckLakeCatalogStore, "ducklake-catalog-store", cfg.DuckLakeCatalogStore, "DuckLake catalog store: sqlite or duckdb")
 	syncCmd.Flags().StringVar(&cfg.DuckLakeDataPath, "ducklake-data-path", cfg.DuckLakeDataPath, "DuckLake data path (defaults to s3://bucket/prefix/ducklake/)")
 	syncCmd.Flags().StringVar(&cfg.SlotName, "slot-name", cfg.SlotName, "Replication slot name")
 	syncCmd.Flags().IntVar(&cfg.FlushRows, "flush-rows", cfg.FlushRows, "Row buffer flush threshold")
@@ -75,7 +76,8 @@ func main() {
 	queryCmd.Flags().StringVar(&cfg.S3Endpoint, "s3-endpoint", cfg.S3Endpoint, "Custom S3 endpoint (MinIO)")
 	queryCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
 	queryCmd.Flags().StringVar(&cfg.TargetFormat, "target-format", cfg.TargetFormat, "Lakehouse target format: iceberg or ducklake")
-	queryCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake SQLite catalog path")
+	queryCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake catalog path")
+	queryCmd.Flags().StringVar(&cfg.DuckLakeCatalogStore, "ducklake-catalog-store", cfg.DuckLakeCatalogStore, "DuckLake catalog store: sqlite or duckdb")
 	queryCmd.Flags().StringVar(&cfg.DuckLakeDataPath, "ducklake-data-path", cfg.DuckLakeDataPath, "DuckLake data path (defaults to s3://bucket/prefix/ducklake/)")
 	queryCmd.Flags().StringVar(&cfg.QueryAddr, "listen-addr", cfg.QueryAddr, "Listen address for query server")
 	queryCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
@@ -180,7 +182,8 @@ snapshot LSN are silently discarded for this table to avoid duplicates.`,
 	resyncCmd.Flags().StringVar(&cfg.S3Region, "s3-region", cfg.S3Region, "AWS region")
 	resyncCmd.Flags().StringVar(&cfg.StatePath, "state-path", cfg.StatePath, "SQLite state file path")
 	resyncCmd.Flags().StringVar(&cfg.TargetFormat, "target-format", cfg.TargetFormat, "Lakehouse target format: iceberg or ducklake")
-	resyncCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake SQLite catalog path")
+	resyncCmd.Flags().StringVar(&cfg.DuckLakeCatalog, "ducklake-catalog", cfg.DuckLakeCatalog, "DuckLake catalog path")
+	resyncCmd.Flags().StringVar(&cfg.DuckLakeCatalogStore, "ducklake-catalog-store", cfg.DuckLakeCatalogStore, "DuckLake catalog store: sqlite or duckdb")
 	resyncCmd.Flags().StringVar(&cfg.DuckLakeDataPath, "ducklake-data-path", cfg.DuckLakeDataPath, "DuckLake data path (defaults to s3://bucket/prefix/ducklake/)")
 	resyncCmd.Flags().IntVar(&cfg.FlushRows, "flush-rows", cfg.FlushRows, "Rows per parquet file / Iceberg snapshot")
 	resyncCmd.Flags().StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (DEBUG, INFO, WARN, ERROR)")
@@ -214,6 +217,8 @@ func runSync(cmd *cobra.Command, args []string) error {
 			cfg.TargetFormat = strings.ToLower(f.Value.String())
 		case "ducklake-catalog":
 			cfg.DuckLakeCatalog = f.Value.String()
+		case "ducklake-catalog-store":
+			cfg.DuckLakeCatalogStore = strings.ToLower(f.Value.String())
 		case "ducklake-data-path":
 			cfg.DuckLakeDataPath = f.Value.String()
 		case "slot-name":
@@ -289,10 +294,11 @@ func runSync(cmd *cobra.Command, args []string) error {
 	makeWriter := func() (pipeline.Writer, error) {
 		if cfg.TargetFormat == "ducklake" {
 			w, err := ducklake.NewWriter(ctx, ducklake.Config{
-				CatalogPath: cfg.DuckLakeCatalog,
-				DataPath:    cfg.EffectiveDuckLakeDataPath(),
-				S3Endpoint:  cfg.S3Endpoint,
-				S3Region:    cfg.S3Region,
+				CatalogPath:  cfg.DuckLakeCatalog,
+				CatalogStore: cfg.DuckLakeCatalogStore,
+				DataPath:     cfg.EffectiveDuckLakeDataPath(),
+				S3Endpoint:   cfg.S3Endpoint,
+				S3Region:     cfg.S3Region,
 			}, stateStore, cfg.FlushRows, cfg.FlushInterval, logger)
 			if err != nil {
 				return nil, err
@@ -322,14 +328,15 @@ func runSync(cmd *cobra.Command, args []string) error {
 	// Start query server if --query-addr is set
 	if cfg.QueryAddr != "" {
 		querySrv, err := server.NewServer(server.ServerConfig{
-			ListenAddr:       cfg.QueryAddr,
-			S3Bucket:         cfg.S3Bucket,
-			S3Prefix:         cfg.S3Prefix,
-			S3Endpoint:       cfg.S3Endpoint,
-			S3Region:         cfg.S3Region,
-			TargetFormat:     cfg.TargetFormat,
-			DuckLakeCatalog:  cfg.DuckLakeCatalog,
-			DuckLakeDataPath: cfg.EffectiveDuckLakeDataPath(),
+			ListenAddr:           cfg.QueryAddr,
+			S3Bucket:             cfg.S3Bucket,
+			S3Prefix:             cfg.S3Prefix,
+			S3Endpoint:           cfg.S3Endpoint,
+			S3Region:             cfg.S3Region,
+			TargetFormat:         cfg.TargetFormat,
+			DuckLakeCatalog:      cfg.DuckLakeCatalog,
+			DuckLakeCatalogStore: cfg.DuckLakeCatalogStore,
+			DuckLakeDataPath:     cfg.EffectiveDuckLakeDataPath(),
 		}, s3Client, logger)
 		if err != nil {
 			return fmt.Errorf("create query server: %w", err)
@@ -550,6 +557,8 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			cfg.TargetFormat = strings.ToLower(f.Value.String())
 		case "ducklake-catalog":
 			cfg.DuckLakeCatalog = f.Value.String()
+		case "ducklake-catalog-store":
+			cfg.DuckLakeCatalogStore = strings.ToLower(f.Value.String())
 		case "ducklake-data-path":
 			cfg.DuckLakeDataPath = f.Value.String()
 		case "listen-addr":
@@ -595,14 +604,15 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 
 	querySrv, err := server.NewServer(server.ServerConfig{
-		ListenAddr:       cfg.QueryAddr,
-		S3Bucket:         cfg.S3Bucket,
-		S3Prefix:         cfg.S3Prefix,
-		S3Endpoint:       cfg.S3Endpoint,
-		S3Region:         cfg.S3Region,
-		TargetFormat:     cfg.TargetFormat,
-		DuckLakeCatalog:  cfg.DuckLakeCatalog,
-		DuckLakeDataPath: cfg.EffectiveDuckLakeDataPath(),
+		ListenAddr:           cfg.QueryAddr,
+		S3Bucket:             cfg.S3Bucket,
+		S3Prefix:             cfg.S3Prefix,
+		S3Endpoint:           cfg.S3Endpoint,
+		S3Region:             cfg.S3Region,
+		TargetFormat:         cfg.TargetFormat,
+		DuckLakeCatalog:      cfg.DuckLakeCatalog,
+		DuckLakeCatalogStore: cfg.DuckLakeCatalogStore,
+		DuckLakeDataPath:     cfg.EffectiveDuckLakeDataPath(),
 	}, s3Client, logger)
 	if err != nil {
 		return fmt.Errorf("create query server: %w", err)
@@ -939,6 +949,8 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 			cfg.TargetFormat = strings.ToLower(f.Value.String())
 		case "ducklake-catalog":
 			cfg.DuckLakeCatalog = f.Value.String()
+		case "ducklake-catalog-store":
+			cfg.DuckLakeCatalogStore = strings.ToLower(f.Value.String())
 		case "ducklake-data-path":
 			cfg.DuckLakeDataPath = f.Value.String()
 		case "flush-rows":
@@ -970,6 +982,9 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 	}
 	if cfg.TargetFormat == "ducklake" && cfg.DuckLakeCatalog == "" {
 		return fmt.Errorf("--ducklake-catalog is required when --target-format=ducklake")
+	}
+	if cfg.DuckLakeCatalogStore != "sqlite" && cfg.DuckLakeCatalogStore != "duckdb" {
+		return fmt.Errorf("--ducklake-catalog-store must be one of: sqlite, duckdb")
 	}
 
 	logger := setupLogger(cfg.LogLevel)
@@ -1062,10 +1077,11 @@ func runResync(cmd *cobra.Command, table string, force bool) error {
 	// 4. Run the backfill.
 	if cfg.TargetFormat == "ducklake" {
 		writer, err := ducklake.NewWriter(ctx, ducklake.Config{
-			CatalogPath: cfg.DuckLakeCatalog,
-			DataPath:    cfg.EffectiveDuckLakeDataPath(),
-			S3Endpoint:  cfg.S3Endpoint,
-			S3Region:    cfg.S3Region,
+			CatalogPath:  cfg.DuckLakeCatalog,
+			CatalogStore: cfg.DuckLakeCatalogStore,
+			DataPath:     cfg.EffectiveDuckLakeDataPath(),
+			S3Endpoint:   cfg.S3Endpoint,
+			S3Region:     cfg.S3Region,
 		}, stateStore, cfg.FlushRows, cfg.FlushInterval, logger)
 		if err != nil {
 			return fmt.Errorf("create ducklake writer: %w", err)

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	S3Endpoint       string
 	S3Region         string
 	StatePath        string
+	TargetFormat     string // lakehouse target: "iceberg" or "ducklake"
+	DuckLakeCatalog  string // SQLite catalog DB path for DuckLake metadata
+	DuckLakeDataPath string // DuckLake data path (defaults to s3://bucket/prefix/ducklake/)
 	SlotName         string
 	FlushRows        int
 	FlushInterval    time.Duration
@@ -31,6 +34,8 @@ func Default() *Config {
 		S3Prefix:         "streambed/",
 		S3Region:         "us-east-1",
 		StatePath:        defaultStatePath(),
+		TargetFormat:     "iceberg",
+		DuckLakeCatalog:  defaultDuckLakeCatalogPath(),
 		SlotName:         "streambed",
 		FlushRows:        10000,
 		FlushInterval:    2 * time.Second,
@@ -46,6 +51,14 @@ func defaultStatePath() string {
 		return ".streambed/state.db"
 	}
 	return home + "/.streambed/state.db"
+}
+
+func defaultDuckLakeCatalogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".streambed/ducklake-catalog.sqlite"
+	}
+	return home + "/.streambed/ducklake-catalog.sqlite"
 }
 
 // Load reads configuration from environment variables.
@@ -70,6 +83,15 @@ func Load() *Config {
 	}
 	if v := os.Getenv("STREAMBED_STATE_PATH"); v != "" {
 		cfg.StatePath = v
+	}
+	if v := os.Getenv("STREAMBED_TARGET_FORMAT"); v != "" {
+		cfg.TargetFormat = strings.ToLower(v)
+	}
+	if v := os.Getenv("STREAMBED_DUCKLAKE_CATALOG"); v != "" {
+		cfg.DuckLakeCatalog = v
+	}
+	if v := os.Getenv("STREAMBED_DUCKLAKE_DATA_PATH"); v != "" {
+		cfg.DuckLakeDataPath = v
 	}
 	if v := os.Getenv("STREAMBED_SLOT_NAME"); v != "" {
 		cfg.SlotName = v
@@ -130,6 +152,12 @@ func (c *Config) Validate() error {
 	if len(c.IncludeTables) > 0 && len(c.ExcludeTables) > 0 {
 		return fmt.Errorf("cannot use both --include-tables and --exclude-tables")
 	}
+	if c.TargetFormat != "iceberg" && c.TargetFormat != "ducklake" {
+		return fmt.Errorf("target-format must be one of: iceberg, ducklake")
+	}
+	if c.TargetFormat == "ducklake" && c.DuckLakeCatalog == "" {
+		return fmt.Errorf("ducklake-catalog is required when target-format=ducklake")
+	}
 	if c.FlushRows <= 0 {
 		return fmt.Errorf("flush-rows must be positive")
 	}
@@ -151,8 +179,32 @@ func (c *Config) ValidateQuery() error {
 	if c.S3Bucket == "" {
 		return fmt.Errorf("s3-bucket is required")
 	}
+	if c.TargetFormat != "iceberg" && c.TargetFormat != "ducklake" {
+		return fmt.Errorf("target-format must be one of: iceberg, ducklake")
+	}
+	if c.TargetFormat == "ducklake" && c.DuckLakeCatalog == "" {
+		return fmt.Errorf("ducklake-catalog is required when target-format=ducklake")
+	}
 	if c.QueryAddr == "" {
 		return fmt.Errorf("listen-addr is required")
 	}
 	return nil
+}
+
+func (c *Config) EffectiveDuckLakeDataPath() string {
+	if c.DuckLakeDataPath != "" {
+		return ensureTrailingSlash(c.DuckLakeDataPath)
+	}
+	prefix := strings.Trim(c.S3Prefix, "/")
+	if prefix == "" {
+		return fmt.Sprintf("s3://%s/ducklake/", c.S3Bucket)
+	}
+	return fmt.Sprintf("s3://%s/%s/ducklake/", c.S3Bucket, prefix)
+}
+
+func ensureTrailingSlash(s string) string {
+	if strings.HasSuffix(s, "/") {
+		return s
+	}
+	return s + "/"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -9,39 +9,41 @@ import (
 )
 
 type Config struct {
-	SourceURL        string
-	S3Bucket         string
-	S3Prefix         string
-	S3Endpoint       string
-	S3Region         string
-	StatePath        string
-	TargetFormat     string // lakehouse target: "iceberg" or "ducklake"
-	DuckLakeCatalog  string // SQLite catalog DB path for DuckLake metadata
-	DuckLakeDataPath string // DuckLake data path (defaults to s3://bucket/prefix/ducklake/)
-	SlotName         string
-	FlushRows        int
-	FlushInterval    time.Duration
-	TargetFileSizeMB int
-	IncludeTables    []string
-	ExcludeTables    []string
-	LogLevel         string
-	MutationMode     string // Iceberg row mutation strategy: "cow" or "mor"
-	QueryAddr        string // listen address for query server (e.g., ":5433")
+	SourceURL            string
+	S3Bucket             string
+	S3Prefix             string
+	S3Endpoint           string
+	S3Region             string
+	StatePath            string
+	TargetFormat         string // lakehouse target: "iceberg" or "ducklake"
+	DuckLakeCatalog      string // catalog DB path for DuckLake metadata
+	DuckLakeCatalogStore string // DuckLake catalog store: "sqlite" (default) or "duckdb"
+	DuckLakeDataPath     string // DuckLake data path (defaults to s3://bucket/prefix/ducklake/)
+	SlotName             string
+	FlushRows            int
+	FlushInterval        time.Duration
+	TargetFileSizeMB     int
+	IncludeTables        []string
+	ExcludeTables        []string
+	LogLevel             string
+	MutationMode         string // Iceberg row mutation strategy: "cow" or "mor"
+	QueryAddr            string // listen address for query server (e.g., ":5433")
 }
 
 func Default() *Config {
 	return &Config{
-		S3Prefix:         "streambed/",
-		S3Region:         "us-east-1",
-		StatePath:        defaultStatePath(),
-		TargetFormat:     "iceberg",
-		DuckLakeCatalog:  defaultDuckLakeCatalogPath(),
-		SlotName:         "streambed",
-		FlushRows:        10000,
-		FlushInterval:    2 * time.Second,
-		TargetFileSizeMB: 128,
-		LogLevel:         "INFO",
-		MutationMode:     "cow",
+		S3Prefix:             "streambed/",
+		S3Region:             "us-east-1",
+		StatePath:            defaultStatePath(),
+		TargetFormat:         "iceberg",
+		DuckLakeCatalog:      defaultDuckLakeCatalogPath(),
+		DuckLakeCatalogStore: "sqlite",
+		SlotName:             "streambed",
+		FlushRows:            10000,
+		FlushInterval:        2 * time.Second,
+		TargetFileSizeMB:     128,
+		LogLevel:             "INFO",
+		MutationMode:         "cow",
 	}
 }
 
@@ -89,6 +91,9 @@ func Load() *Config {
 	}
 	if v := os.Getenv("STREAMBED_DUCKLAKE_CATALOG"); v != "" {
 		cfg.DuckLakeCatalog = v
+	}
+	if v := os.Getenv("STREAMBED_DUCKLAKE_CATALOG_STORE"); v != "" {
+		cfg.DuckLakeCatalogStore = strings.ToLower(v)
 	}
 	if v := os.Getenv("STREAMBED_DUCKLAKE_DATA_PATH"); v != "" {
 		cfg.DuckLakeDataPath = v
@@ -158,6 +163,9 @@ func (c *Config) Validate() error {
 	if c.TargetFormat == "ducklake" && c.DuckLakeCatalog == "" {
 		return fmt.Errorf("ducklake-catalog is required when target-format=ducklake")
 	}
+	if c.DuckLakeCatalogStore != "sqlite" && c.DuckLakeCatalogStore != "duckdb" {
+		return fmt.Errorf("ducklake-catalog-store must be one of: sqlite, duckdb")
+	}
 	if c.FlushRows <= 0 {
 		return fmt.Errorf("flush-rows must be positive")
 	}
@@ -184,6 +192,9 @@ func (c *Config) ValidateQuery() error {
 	}
 	if c.TargetFormat == "ducklake" && c.DuckLakeCatalog == "" {
 		return fmt.Errorf("ducklake-catalog is required when target-format=ducklake")
+	}
+	if c.DuckLakeCatalogStore != "sqlite" && c.DuckLakeCatalogStore != "duckdb" {
+		return fmt.Errorf("ducklake-catalog-store must be one of: sqlite, duckdb")
 	}
 	if c.QueryAddr == "" {
 		return fmt.Errorf("listen-addr is required")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,9 @@ func TestDefaults(t *testing.T) {
 	if cfg.DuckLakeCatalog == "" {
 		t.Error("expected DuckLakeCatalog default")
 	}
+	if cfg.DuckLakeCatalogStore != "sqlite" {
+		t.Errorf("expected DuckLakeCatalogStore 'sqlite', got %q", cfg.DuckLakeCatalogStore)
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -51,7 +54,8 @@ func TestLoadFromEnv(t *testing.T) {
 	os.Setenv("STREAMBED_LOG_LEVEL", "debug")
 	os.Setenv("STREAMBED_MUTATION_MODE", "mor")
 	os.Setenv("STREAMBED_TARGET_FORMAT", "ducklake")
-	os.Setenv("STREAMBED_DUCKLAKE_CATALOG", "/tmp/streambed-ducklake.sqlite")
+	os.Setenv("STREAMBED_DUCKLAKE_CATALOG", "/tmp/streambed-ducklake.ducklake")
+	os.Setenv("STREAMBED_DUCKLAKE_CATALOG_STORE", "duckdb")
 	os.Setenv("STREAMBED_DUCKLAKE_DATA_PATH", "s3://my-bucket/data/ducklake")
 	defer func() {
 		os.Unsetenv("STREAMBED_SOURCE_URL")
@@ -65,6 +69,7 @@ func TestLoadFromEnv(t *testing.T) {
 		os.Unsetenv("STREAMBED_MUTATION_MODE")
 		os.Unsetenv("STREAMBED_TARGET_FORMAT")
 		os.Unsetenv("STREAMBED_DUCKLAKE_CATALOG")
+		os.Unsetenv("STREAMBED_DUCKLAKE_CATALOG_STORE")
 		os.Unsetenv("STREAMBED_DUCKLAKE_DATA_PATH")
 	}()
 
@@ -99,8 +104,11 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.TargetFormat != "ducklake" {
 		t.Errorf("expected TargetFormat 'ducklake', got %q", cfg.TargetFormat)
 	}
-	if cfg.DuckLakeCatalog != "/tmp/streambed-ducklake.sqlite" {
+	if cfg.DuckLakeCatalog != "/tmp/streambed-ducklake.ducklake" {
 		t.Errorf("expected DuckLakeCatalog from env, got %q", cfg.DuckLakeCatalog)
+	}
+	if cfg.DuckLakeCatalogStore != "duckdb" {
+		t.Errorf("expected DuckLakeCatalogStore from env, got %q", cfg.DuckLakeCatalogStore)
 	}
 	if got := cfg.EffectiveDuckLakeDataPath(); got != "s3://my-bucket/data/ducklake/" {
 		t.Errorf("expected normalized DuckLake data path, got %q", got)
@@ -126,20 +134,23 @@ func TestValidate(t *testing.T) {
 			c.TargetFormat = "ducklake"
 			c.DuckLakeCatalog = ""
 		}, "ducklake-catalog is required"},
+		{"invalid ducklake catalog store", func(c *Config) { c.DuckLakeCatalogStore = "mysql" }, "ducklake-catalog-store must be one of"},
+		{"valid duckdb catalog store", func(c *Config) { c.DuckLakeCatalogStore = "duckdb" }, ""},
 		{"valid config", func(c *Config) {}, ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
-				SourceURL:        "postgres://localhost/test",
-				S3Bucket:         "bucket",
-				FlushRows:        10000,
-				FlushInterval:    30 * time.Second,
-				TargetFileSizeMB: 128,
-				TargetFormat:     "iceberg",
-				DuckLakeCatalog:  "/tmp/ducklake.sqlite",
-				MutationMode:     "cow",
+				SourceURL:            "postgres://localhost/test",
+				S3Bucket:             "bucket",
+				FlushRows:            10000,
+				FlushInterval:        30 * time.Second,
+				TargetFileSizeMB:     128,
+				TargetFormat:         "iceberg",
+				DuckLakeCatalog:      "/tmp/ducklake.sqlite",
+				DuckLakeCatalogStore: "sqlite",
+				MutationMode:         "cow",
 			}
 			tt.modify(cfg)
 			err := cfg.Validate()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,12 @@ func TestDefaults(t *testing.T) {
 	if cfg.MutationMode != "cow" {
 		t.Errorf("expected MutationMode 'cow', got %q", cfg.MutationMode)
 	}
+	if cfg.TargetFormat != "iceberg" {
+		t.Errorf("expected TargetFormat 'iceberg', got %q", cfg.TargetFormat)
+	}
+	if cfg.DuckLakeCatalog == "" {
+		t.Error("expected DuckLakeCatalog default")
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -44,6 +50,9 @@ func TestLoadFromEnv(t *testing.T) {
 	os.Setenv("STREAMBED_INCLUDE_TABLES", "public.orders, public.users")
 	os.Setenv("STREAMBED_LOG_LEVEL", "debug")
 	os.Setenv("STREAMBED_MUTATION_MODE", "mor")
+	os.Setenv("STREAMBED_TARGET_FORMAT", "ducklake")
+	os.Setenv("STREAMBED_DUCKLAKE_CATALOG", "/tmp/streambed-ducklake.sqlite")
+	os.Setenv("STREAMBED_DUCKLAKE_DATA_PATH", "s3://my-bucket/data/ducklake")
 	defer func() {
 		os.Unsetenv("STREAMBED_SOURCE_URL")
 		os.Unsetenv("STREAMBED_S3_BUCKET")
@@ -54,6 +63,9 @@ func TestLoadFromEnv(t *testing.T) {
 		os.Unsetenv("STREAMBED_INCLUDE_TABLES")
 		os.Unsetenv("STREAMBED_LOG_LEVEL")
 		os.Unsetenv("STREAMBED_MUTATION_MODE")
+		os.Unsetenv("STREAMBED_TARGET_FORMAT")
+		os.Unsetenv("STREAMBED_DUCKLAKE_CATALOG")
+		os.Unsetenv("STREAMBED_DUCKLAKE_DATA_PATH")
 	}()
 
 	cfg := Load()
@@ -84,6 +96,15 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.MutationMode != "mor" {
 		t.Errorf("expected MutationMode 'mor', got %q", cfg.MutationMode)
 	}
+	if cfg.TargetFormat != "ducklake" {
+		t.Errorf("expected TargetFormat 'ducklake', got %q", cfg.TargetFormat)
+	}
+	if cfg.DuckLakeCatalog != "/tmp/streambed-ducklake.sqlite" {
+		t.Errorf("expected DuckLakeCatalog from env, got %q", cfg.DuckLakeCatalog)
+	}
+	if got := cfg.EffectiveDuckLakeDataPath(); got != "s3://my-bucket/data/ducklake/" {
+		t.Errorf("expected normalized DuckLake data path, got %q", got)
+	}
 }
 
 func TestValidate(t *testing.T) {
@@ -100,6 +121,11 @@ func TestValidate(t *testing.T) {
 		}, "cannot use both"},
 		{"invalid mutation mode", func(c *Config) { c.MutationMode = "invalid" }, "mutation-mode must be one of"},
 		{"mor mutation mode", func(c *Config) { c.MutationMode = "mor" }, ""},
+		{"invalid target format", func(c *Config) { c.TargetFormat = "delta" }, "target-format must be one of"},
+		{"ducklake missing catalog", func(c *Config) {
+			c.TargetFormat = "ducklake"
+			c.DuckLakeCatalog = ""
+		}, "ducklake-catalog is required"},
 		{"valid config", func(c *Config) {}, ""},
 	}
 
@@ -111,6 +137,8 @@ func TestValidate(t *testing.T) {
 				FlushRows:        10000,
 				FlushInterval:    30 * time.Second,
 				TargetFileSizeMB: 128,
+				TargetFormat:     "iceberg",
+				DuckLakeCatalog:  "/tmp/ducklake.sqlite",
 				MutationMode:     "cow",
 			}
 			tt.modify(cfg)

--- a/internal/ducklake/resync.go
+++ b/internal/ducklake/resync.go
@@ -1,0 +1,114 @@
+package ducklake
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/viggy28/streambed/internal/state"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+type ResyncOptions struct {
+	Schema, Table string
+	FlushRows     int
+	ReplConn      *pgconn.PgConn
+	DataConn      *pgconn.PgConn
+	State         *state.Store
+	Writer        *Writer
+	Logger        *slog.Logger
+}
+
+type ResyncStats struct {
+	Rows         int64
+	Batches      int
+	BackfillLSN  string
+	SnapshotName string
+}
+
+func RunResync(ctx context.Context, opts ResyncOptions) (ResyncStats, error) {
+	var stats ResyncStats
+	if opts.FlushRows <= 0 {
+		opts.FlushRows = 10000
+	}
+	columns, err := wal.FetchTableColumns(ctx, opts.DataConn, opts.Schema, opts.Table)
+	if err != nil {
+		return stats, fmt.Errorf("fetch columns: %w", err)
+	}
+	walColumns := make([]wal.Column, len(columns))
+	for i, c := range columns {
+		walColumns[i] = wal.Column{Name: c.Name, OID: c.OID}
+	}
+	if err := opts.Writer.DropTable(ctx, opts.Schema, opts.Table); err != nil {
+		return stats, fmt.Errorf("drop existing ducklake table: %w", err)
+	}
+	slotName := "sb_resync_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+	tmp, err := wal.CreateTempSlotWithSnapshot(ctx, opts.ReplConn, slotName, opts.Logger)
+	if err != nil {
+		return stats, fmt.Errorf("create temp slot: %w", err)
+	}
+	stats.SnapshotName = tmp.SnapshotName
+	stats.BackfillLSN = tmp.ConsistentPoint.String()
+
+	batchRows := 0
+	rowFn := func(row wal.BackfillRow) error {
+		values := make([]wal.ColumnValue, len(row.Values))
+		for i, v := range row.Values {
+			values[i] = wal.ColumnValue{
+				Name:   v.Name,
+				OID:    v.OID,
+				IsNull: v.IsNull,
+			}
+			if !v.IsNull {
+				values[i].Value = append([]byte(nil), v.Value...)
+			}
+		}
+		if _, err := opts.Writer.HandleEvent(ctx, wal.RowEvent{
+			Schema:      opts.Schema,
+			Table:       opts.Table,
+			Columns:     walColumns,
+			Op:          wal.OpInsert,
+			Values:      values,
+			WALStartLSN: tmp.ConsistentPoint,
+		}); err != nil {
+			return err
+		}
+		batchRows++
+		if batchRows >= opts.FlushRows {
+			if err := opts.Writer.FlushAll(ctx); err != nil {
+				return err
+			}
+			stats.Batches++
+			batchRows = 0
+		}
+		return nil
+	}
+	count, err := wal.CopyTableUnderSnapshot(ctx, opts.DataConn, tmp.SnapshotName, opts.Schema, opts.Table, columns, rowFn, opts.Logger)
+	if err != nil {
+		return stats, fmt.Errorf("copy under snapshot: %w", err)
+	}
+	stats.Rows = count
+	if batchRows > 0 {
+		if err := opts.Writer.FlushAll(ctx); err != nil {
+			return stats, err
+		}
+		stats.Batches++
+	}
+	if err := opts.State.RegisterTable(opts.Schema, opts.Table, len(columns)); err != nil {
+		return stats, fmt.Errorf("register table in state: %w", err)
+	}
+	if err := opts.State.SetBackfillLSN(opts.Schema, opts.Table, tmp.ConsistentPoint); err != nil {
+		return stats, fmt.Errorf("set backfill_lsn: %w", err)
+	}
+	opts.Logger.Info("ducklake resync complete",
+		"schema", opts.Schema,
+		"table", opts.Table,
+		"rows", stats.Rows,
+		"batches", stats.Batches,
+		"backfill_lsn", stats.BackfillLSN,
+	)
+	return stats, nil
+}

--- a/internal/ducklake/types.go
+++ b/internal/ducklake/types.go
@@ -1,0 +1,288 @@
+package ducklake
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	duckdb "github.com/duckdb/duckdb-go/v2"
+	"github.com/google/uuid"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+func quoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+func qname(catalog, schema, table string) string {
+	return quoteIdent(catalog) + "." + quoteIdent(schema) + "." + quoteIdent(table)
+}
+
+func pgOIDToDuckDBType(oid uint32) string {
+	switch oid {
+	case 16:
+		return "BOOLEAN"
+	case 21:
+		return "SMALLINT"
+	case 23:
+		return "INTEGER"
+	case 20:
+		return "BIGINT"
+	case 700:
+		return "REAL"
+	case 701:
+		return "DOUBLE"
+	case 1082:
+		return "DATE"
+	case 1114:
+		return "TIMESTAMP"
+	case 1184:
+		return "TIMESTAMPTZ"
+	case 2950:
+		return "UUID"
+	case 17:
+		return "BLOB"
+	default:
+		return "VARCHAR"
+	}
+}
+
+func pgOIDToDuckDBAppenderType(oid uint32) duckdb.Type {
+	switch oid {
+	case 16:
+		return duckdb.TYPE_BOOLEAN
+	case 21:
+		return duckdb.TYPE_SMALLINT
+	case 23:
+		return duckdb.TYPE_INTEGER
+	case 20:
+		return duckdb.TYPE_BIGINT
+	case 700:
+		return duckdb.TYPE_FLOAT
+	case 701:
+		return duckdb.TYPE_DOUBLE
+	case 1082:
+		return duckdb.TYPE_DATE
+	case 1114:
+		return duckdb.TYPE_TIMESTAMP
+	case 1184:
+		return duckdb.TYPE_TIMESTAMP_TZ
+	case 2950:
+		return duckdb.TYPE_UUID
+	case 17:
+		return duckdb.TYPE_BLOB
+	default:
+		return duckdb.TYPE_VARCHAR
+	}
+}
+
+func typeInfos(columns []wal.Column) ([]duckdb.TypeInfo, error) {
+	infos := make([]duckdb.TypeInfo, len(columns))
+	for i, col := range columns {
+		info, err := duckdb.NewTypeInfo(pgOIDToDuckDBAppenderType(col.OID))
+		if err != nil {
+			return nil, fmt.Errorf("column %s: %w", col.Name, err)
+		}
+		infos[i] = info
+	}
+	return infos, nil
+}
+
+func columnNames(columns []wal.Column) []string {
+	names := make([]string, len(columns))
+	for i, c := range columns {
+		names[i] = c.Name
+	}
+	return names
+}
+
+func parseValue(oid uint32, data []byte) (any, error) {
+	s := string(data)
+	switch oid {
+	case 16:
+		return s == "t" || s == "true" || s == "TRUE", nil
+	case 21:
+		v, err := strconv.ParseInt(s, 10, 16)
+		return int16(v), err
+	case 23:
+		v, err := strconv.ParseInt(s, 10, 32)
+		return int32(v), err
+	case 20:
+		return strconv.ParseInt(s, 10, 64)
+	case 700:
+		v, err := strconv.ParseFloat(s, 32)
+		return float32(v), err
+	case 701:
+		return strconv.ParseFloat(s, 64)
+	case 1082:
+		return time.Parse("2006-01-02", s)
+	case 1114:
+		return parseTimestamp(s)
+	case 1184:
+		return parseTimestampTZ(s)
+	case 2950:
+		id, err := uuid.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+		var out duckdb.UUID
+		copy(out[:], id[:])
+		return out, nil
+	case 17:
+		return parseBytea(s)
+	default:
+		return s, nil
+	}
+}
+
+func parseBytea(s string) ([]byte, error) {
+	if strings.HasPrefix(s, `\x`) || strings.HasPrefix(s, `\X`) {
+		return hex.DecodeString(s[2:])
+	}
+	return []byte(s), nil
+}
+
+func parseTimestamp(s string) (time.Time, error) {
+	formats := []string{
+		"2006-01-02 15:04:05.999999",
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05.999999",
+		"2006-01-02T15:04:05",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse timestamp %q", s)
+}
+
+func parseTimestampTZ(s string) (time.Time, error) {
+	formats := []string{
+		"2006-01-02 15:04:05.999999-07",
+		"2006-01-02 15:04:05-07",
+		"2006-01-02 15:04:05.999999+00",
+		"2006-01-02 15:04:05+00",
+		time.RFC3339Nano,
+		time.RFC3339,
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	t, err := parseTimestamp(strings.TrimRight(s, "Z"))
+	if err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("cannot parse timestamptz %q", s)
+}
+
+func columnDDL(columns []wal.Column) string {
+	parts := make([]string, len(columns))
+	for i, c := range columns {
+		parts[i] = fmt.Sprintf("%s %s", quoteIdent(c.Name), pgOIDToDuckDBType(c.OID))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func columnList(columns []wal.Column) string {
+	parts := make([]string, len(columns))
+	for i, c := range columns {
+		parts[i] = quoteIdent(c.Name)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func keyColumns(columns []wal.Column, keyIdx []int) []wal.Column {
+	out := make([]wal.Column, 0, len(keyIdx))
+	for _, idx := range keyIdx {
+		if idx >= 0 && idx < len(columns) {
+			out = append(out, columns[idx])
+		}
+	}
+	return out
+}
+
+func keyPredicate(tableAlias, keyAlias string, keys []wal.Column) string {
+	parts := make([]string, len(keys))
+	for i, c := range keys {
+		col := quoteIdent(c.Name)
+		parts[i] = fmt.Sprintf("%s.%s IS NOT DISTINCT FROM %s.%s", tableAlias, col, keyAlias, col)
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func columnsFingerprint(columns []wal.Column) string {
+	var b strings.Builder
+	for _, c := range columns {
+		b.WriteString(c.Name)
+		b.WriteByte(':')
+		b.WriteString(strconv.FormatUint(uint64(c.OID), 10))
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
+func dedupRowsByKey(columns []wal.Column, keyIdx []int, rows [][]cell) [][]cell {
+	if len(rows) <= 1 || len(keyIdx) == 0 {
+		return rows
+	}
+	seen := make(map[string]int, len(rows))
+	out := make([][]cell, 0, len(rows))
+	for _, row := range rows {
+		key := rowKey(columns, keyIdx, row)
+		if idx, ok := seen[key]; ok {
+			out[idx] = row
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, row)
+	}
+	return out
+}
+
+func dedupCellRows(rows [][]cell) [][]cell {
+	if len(rows) <= 1 {
+		return rows
+	}
+	seen := make(map[string]int, len(rows))
+	out := make([][]cell, 0, len(rows))
+	for _, row := range rows {
+		key := cellsKey(row)
+		if idx, ok := seen[key]; ok {
+			out[idx] = row
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, row)
+	}
+	return out
+}
+
+func rowKey(columns []wal.Column, keyIdx []int, row []cell) string {
+	parts := make([]cell, 0, len(keyIdx))
+	for _, idx := range keyIdx {
+		if idx >= 0 && idx < len(columns) && idx < len(row) {
+			parts = append(parts, row[idx])
+		}
+	}
+	return cellsKey(parts)
+}
+
+func cellsKey(row []cell) string {
+	var b strings.Builder
+	for _, c := range row {
+		if c.IsNull {
+			b.WriteString("n;")
+			continue
+		}
+		b.WriteString(strconv.Itoa(len(c.Data)))
+		b.WriteByte(':')
+		b.WriteString(string(c.Data))
+		b.WriteByte(';')
+	}
+	return b.String()
+}

--- a/internal/ducklake/writer.go
+++ b/internal/ducklake/writer.go
@@ -21,11 +21,12 @@ import (
 const defaultCatalogName = "streambed"
 
 type Config struct {
-	CatalogPath string
-	DataPath    string
-	S3Endpoint  string
-	S3Region    string
-	CatalogName string
+	CatalogPath  string
+	CatalogStore string // DuckLake catalog store: "sqlite" (default) or "duckdb"
+	DataPath     string
+	S3Endpoint   string
+	S3Region     string
+	CatalogName  string
 }
 
 type Writer struct {
@@ -95,16 +96,23 @@ func Open(ctx context.Context, cfg Config) (*sql.DB, error) {
 }
 
 func Configure(ctx context.Context, db *sql.DB, cfg Config) error {
+	catalogStore := normalizedCatalogStore(cfg.CatalogStore)
 	stmts := []string{
 		"INSTALL ducklake",
 		"LOAD ducklake",
-		"INSTALL sqlite",
-		"LOAD sqlite",
+	}
+	if catalogStore == "sqlite" {
+		stmts = append(stmts,
+			"INSTALL sqlite",
+			"LOAD sqlite",
+		)
+	}
+	stmts = append(stmts,
 		"INSTALL httpfs",
 		"LOAD httpfs",
 		"INSTALL icu",
 		"LOAD icu",
-	}
+	)
 	if cfg.S3Region != "" {
 		stmts = append(stmts, fmt.Sprintf("SET GLOBAL s3_region = '%s'", strings.ReplaceAll(cfg.S3Region, "'", "''")))
 	}
@@ -135,8 +143,8 @@ func Configure(ctx context.Context, db *sql.DB, cfg Config) error {
 			return fmt.Errorf("exec %q: %w", stmt, err)
 		}
 	}
-	attach := fmt.Sprintf("ATTACH 'ducklake:sqlite:%s' AS %s (DATA_PATH '%s')",
-		strings.ReplaceAll(cfg.CatalogPath, "'", "''"),
+	attach := fmt.Sprintf("ATTACH '%s' AS %s (DATA_PATH '%s')",
+		duckLakeAttachPath(cfg.CatalogPath, catalogStore),
 		quoteIdent(catalogName(cfg)),
 		strings.ReplaceAll(cfg.DataPath, "'", "''"),
 	)
@@ -144,6 +152,21 @@ func Configure(ctx context.Context, db *sql.DB, cfg Config) error {
 		return fmt.Errorf("attach ducklake catalog: %w", err)
 	}
 	return nil
+}
+
+func normalizedCatalogStore(store string) string {
+	if strings.EqualFold(store, "duckdb") {
+		return "duckdb"
+	}
+	return "sqlite"
+}
+
+func duckLakeAttachPath(catalogPath, catalogStore string) string {
+	escapedPath := strings.ReplaceAll(catalogPath, "'", "''")
+	if catalogStore == "duckdb" {
+		return "ducklake:" + escapedPath
+	}
+	return "ducklake:sqlite:" + escapedPath
 }
 
 func catalogName(cfg Config) string {

--- a/internal/ducklake/writer.go
+++ b/internal/ducklake/writer.go
@@ -1,0 +1,683 @@
+package ducklake
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	duckdb "github.com/duckdb/duckdb-go/v2"
+	"github.com/jackc/pglogrepl"
+	"github.com/viggy28/streambed/internal/state"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+const defaultCatalogName = "streambed"
+
+type Config struct {
+	CatalogPath string
+	DataPath    string
+	S3Endpoint  string
+	S3Region    string
+	CatalogName string
+}
+
+type Writer struct {
+	db            *sql.DB
+	state         *state.Store
+	flushRows     int
+	flushInterval time.Duration
+	logger        *slog.Logger
+	cfg           Config
+	catalogName   string
+	buffers       map[string]*tableBuffer
+	ensuredTables map[string]string
+}
+
+type tableBuffer struct {
+	Schema     string
+	Table      string
+	Columns    []wal.Column
+	KeyColumns []int
+	Rows       [][]cell
+	Deletes    [][]cell
+	LastLSN    pglogrepl.LSN
+	FirstLSN   pglogrepl.LSN
+}
+
+type cell struct {
+	Data   []byte
+	IsNull bool
+}
+
+func NewWriter(ctx context.Context, cfg Config, store *state.Store, flushRows int, flushInterval time.Duration, logger *slog.Logger) (*Writer, error) {
+	if cfg.CatalogName == "" {
+		cfg.CatalogName = defaultCatalogName
+	}
+	if err := os.MkdirAll(filepath.Dir(cfg.CatalogPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create ducklake catalog directory: %w", err)
+	}
+	db, err := Open(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	w := &Writer{
+		db:            db,
+		state:         store,
+		flushRows:     flushRows,
+		flushInterval: flushInterval,
+		logger:        logger,
+		cfg:           cfg,
+		catalogName:   cfg.CatalogName,
+		buffers:       make(map[string]*tableBuffer),
+		ensuredTables: make(map[string]string),
+	}
+	return w, nil
+}
+
+func Open(ctx context.Context, cfg Config) (*sql.DB, error) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		return nil, fmt.Errorf("open duckdb: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := Configure(ctx, db, cfg); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func Configure(ctx context.Context, db *sql.DB, cfg Config) error {
+	stmts := []string{
+		"INSTALL ducklake",
+		"LOAD ducklake",
+		"INSTALL sqlite",
+		"LOAD sqlite",
+		"INSTALL httpfs",
+		"LOAD httpfs",
+		"INSTALL icu",
+		"LOAD icu",
+	}
+	if cfg.S3Region != "" {
+		stmts = append(stmts, fmt.Sprintf("SET GLOBAL s3_region = '%s'", strings.ReplaceAll(cfg.S3Region, "'", "''")))
+	}
+	if cfg.S3Endpoint != "" {
+		endpoint := strings.TrimPrefix(strings.TrimPrefix(cfg.S3Endpoint, "http://"), "https://")
+		stmts = append(stmts,
+			fmt.Sprintf("SET GLOBAL s3_endpoint = '%s'", strings.ReplaceAll(endpoint, "'", "''")),
+			"SET GLOBAL s3_url_style = 'path'",
+			"SET GLOBAL s3_use_ssl = false",
+		)
+	}
+	key := os.Getenv("AWS_ACCESS_KEY_ID")
+	secret := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if key == "" && cfg.S3Endpoint != "" {
+		key = "minioadmin"
+	}
+	if secret == "" && cfg.S3Endpoint != "" {
+		secret = "minioadmin"
+	}
+	if key != "" {
+		stmts = append(stmts, fmt.Sprintf("SET GLOBAL s3_access_key_id = '%s'", strings.ReplaceAll(key, "'", "''")))
+	}
+	if secret != "" {
+		stmts = append(stmts, fmt.Sprintf("SET GLOBAL s3_secret_access_key = '%s'", strings.ReplaceAll(secret, "'", "''")))
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("exec %q: %w", stmt, err)
+		}
+	}
+	attach := fmt.Sprintf("ATTACH 'ducklake:sqlite:%s' AS %s (DATA_PATH '%s')",
+		strings.ReplaceAll(cfg.CatalogPath, "'", "''"),
+		quoteIdent(catalogName(cfg)),
+		strings.ReplaceAll(cfg.DataPath, "'", "''"),
+	)
+	if _, err := db.ExecContext(ctx, attach); err != nil {
+		return fmt.Errorf("attach ducklake catalog: %w", err)
+	}
+	return nil
+}
+
+func catalogName(cfg Config) string {
+	if cfg.CatalogName == "" {
+		return defaultCatalogName
+	}
+	return cfg.CatalogName
+}
+
+func (w *Writer) Close() error {
+	return w.db.Close()
+}
+
+func (w *Writer) DropTable(ctx context.Context, schema, table string) error {
+	if _, err := w.db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", qname(w.catalogName, schema, table))); err != nil {
+		return err
+	}
+	delete(w.ensuredTables, schema+"."+table)
+	return nil
+}
+
+func (w *Writer) HandleEvent(ctx context.Context, event wal.RowEvent) (bool, error) {
+	if event.Op == wal.OpTruncate {
+		return false, w.Truncate(ctx, event)
+	}
+	transitioned := w.buffer(event)
+	key := event.Schema + "." + event.Table
+	buf := w.buffers[key]
+	if len(buf.Rows)+len(buf.Deletes) >= w.flushRows {
+		if err := w.flush(ctx, key); err != nil {
+			return false, err
+		}
+	}
+	return transitioned, nil
+}
+
+func (w *Writer) HandleSchemaChange(ctx context.Context, rel *wal.RelationMessage, defaults map[string]string) error {
+	key := rel.Namespace + "." + rel.Name
+	if buf, exists := w.buffers[key]; exists && (len(buf.Rows) > 0 || len(buf.Deletes) > 0) {
+		if err := w.flush(ctx, key); err != nil {
+			return fmt.Errorf("pre-evolution flush for %s: %w", key, err)
+		}
+	}
+	buf, exists := w.buffers[key]
+	if !exists {
+		buf = &tableBuffer{Schema: rel.Namespace, Table: rel.Name}
+		w.buffers[key] = buf
+	}
+	tableExists, err := w.tableExists(ctx, rel.Namespace, rel.Name)
+	if err != nil {
+		return err
+	}
+	if tableExists && len(rel.Changes) > 0 {
+		tx, err := w.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		if err := w.applySchemaChanges(ctx, tx, rel, defaults); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := w.setCommitMessage(ctx, tx, rel.Namespace, rel.Name, "schema", ""); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit schema evolution for %s: %w", key, err)
+		}
+		delete(w.ensuredTables, key)
+	}
+	buf.Columns = rel.Columns
+	buf.KeyColumns = rel.KeyColumnIndexes
+	if w.state != nil {
+		if err := w.state.RegisterTable(rel.Namespace, rel.Name, len(rel.Columns)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *Writer) buffer(event wal.RowEvent) bool {
+	key := event.Schema + "." + event.Table
+	buf, exists := w.buffers[key]
+	if !exists {
+		buf = &tableBuffer{
+			Schema:     event.Schema,
+			Table:      event.Table,
+			Columns:    event.Columns,
+			KeyColumns: event.KeyColumns,
+			LastLSN:    event.WALStartLSN,
+		}
+		w.buffers[key] = buf
+		if w.state != nil {
+			if err := w.state.RegisterTable(event.Schema, event.Table, len(event.Columns)); err != nil {
+				w.logger.Warn("register table failed", "table", key, "error", err)
+			}
+		}
+		w.logger.Info("new ducklake table discovered", "schema", event.Schema, "table", event.Table)
+	}
+	if len(event.Columns) > 0 {
+		buf.Columns = event.Columns
+	}
+	if len(event.KeyColumns) > 0 && len(buf.KeyColumns) == 0 {
+		buf.KeyColumns = event.KeyColumns
+	}
+	wasEmpty := len(buf.Rows) == 0 && len(buf.Deletes) == 0
+	if event.Op == wal.OpInsert || event.Op == wal.OpUpdate {
+		row := make([]cell, len(event.Values))
+		for i, v := range event.Values {
+			row[i] = cell{Data: append([]byte(nil), v.Value...), IsNull: v.IsNull || v.IsUnchangedTOAST}
+		}
+		buf.Rows = append(buf.Rows, row)
+	}
+	if event.Op == wal.OpUpdate || event.Op == wal.OpDelete {
+		keyRow := make([]cell, len(event.OldKey))
+		for i, v := range event.OldKey {
+			keyRow[i] = cell{Data: append([]byte(nil), v.Value...), IsNull: v.IsNull}
+		}
+		buf.Deletes = append(buf.Deletes, keyRow)
+	}
+	if event.WALStartLSN > buf.LastLSN {
+		buf.LastLSN = event.WALStartLSN
+	}
+	transitioned := wasEmpty && (len(buf.Rows) > 0 || len(buf.Deletes) > 0)
+	if transitioned {
+		buf.FirstLSN = event.WALStartLSN
+	}
+	return transitioned
+}
+
+func (w *Writer) FlushAll(ctx context.Context) error {
+	keys := make([]string, 0, len(w.buffers))
+	for key := range w.buffers {
+		if buf := w.buffers[key]; buf != nil && (len(buf.Rows) > 0 || len(buf.Deletes) > 0) {
+			keys = append(keys, key)
+		}
+	}
+	return w.flushKeys(ctx, keys)
+}
+
+func (w *Writer) ComputePendingMinLSN() pglogrepl.LSN {
+	var min pglogrepl.LSN
+	for _, buf := range w.buffers {
+		if buf.FirstLSN == 0 {
+			continue
+		}
+		if min == 0 || buf.FirstLSN < min {
+			min = buf.FirstLSN
+		}
+	}
+	return min
+}
+
+func (w *Writer) flush(ctx context.Context, key string) error {
+	return w.flushKeys(ctx, []string{key})
+}
+
+func (w *Writer) flushKeys(ctx context.Context, keys []string) error {
+	type flushedTable struct {
+		key     string
+		buf     *tableBuffer
+		rows    int
+		deletes int
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	start := time.Now()
+	pending := make([]*tableBuffer, 0, len(keys))
+	for _, key := range keys {
+		buf := w.buffers[key]
+		if buf == nil || (len(buf.Rows) == 0 && len(buf.Deletes) == 0) {
+			continue
+		}
+		if len(buf.Deletes) > 0 && len(buf.KeyColumns) == 0 {
+			w.logger.Warn("dropping ducklake deletes for table without key columns", "table", key, "deletes", len(buf.Deletes))
+			buf.Deletes = nil
+		}
+		if len(buf.Rows) == 0 && len(buf.Deletes) == 0 {
+			buf.FirstLSN = 0
+			continue
+		}
+		buf.Rows = dedupRowsByKey(buf.Columns, buf.KeyColumns, buf.Rows)
+		buf.Deletes = dedupCellRows(buf.Deletes)
+		pending = append(pending, buf)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	conn, err := w.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "BEGIN"); err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+	flushed := make([]flushedTable, 0, len(pending))
+	tableLSNs := make(map[string]string, len(pending))
+	for _, buf := range pending {
+		key := buf.Schema + "." + buf.Table
+		rows := len(buf.Rows)
+		deletes := len(buf.Deletes)
+		if err := w.ensureTableForFlush(ctx, conn, key, buf); err != nil {
+			return err
+		}
+		if deletes > 0 {
+			if err := w.stageDeletesAndApply(ctx, conn, buf); err != nil {
+				return err
+			}
+		}
+		if rows > 0 {
+			if err := w.stageRowsAndInsert(ctx, conn, buf); err != nil {
+				return err
+			}
+		}
+		tableLSNs[key] = buf.LastLSN.String()
+		flushed = append(flushed, flushedTable{key: key, buf: buf, rows: rows, deletes: deletes})
+	}
+	if len(flushed) == 1 {
+		buf := flushed[0].buf
+		if err := w.setCommitMessage(ctx, conn, buf.Schema, buf.Table, "flush", buf.LastLSN.String()); err != nil {
+			return err
+		}
+	} else if err := w.setBatchCommitMessage(ctx, conn, tableLSNs); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("commit ducklake flush: %w", err)
+	}
+	committed = true
+	duration := time.Since(start)
+	for _, ft := range flushed {
+		w.logger.Info("ducklake flush completed",
+			"schema", ft.buf.Schema,
+			"table", ft.buf.Table,
+			"rows", ft.rows,
+			"deletes", ft.deletes,
+			"mutation_mode", "delete_insert",
+			"duration_ms", duration.Milliseconds(),
+		)
+		ft.buf.Rows = nil
+		ft.buf.Deletes = nil
+		ft.buf.FirstLSN = 0
+	}
+	return nil
+}
+
+type ducklakeExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+type ducklakeQueryExecer interface {
+	ducklakeExecer
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func (w *Writer) ensureTableForFlush(ctx context.Context, conn *sql.Conn, key string, buf *tableBuffer) error {
+	fp := columnsFingerprint(buf.Columns)
+	if w.ensuredTables[key] == fp {
+		return nil
+	}
+	if err := w.ensureTable(ctx, conn, buf.Schema, buf.Table, buf.Columns); err != nil {
+		return err
+	}
+	if err := w.reconcileTableSchema(ctx, conn, buf.Schema, buf.Table, buf.Columns); err != nil {
+		return err
+	}
+	w.ensuredTables[key] = fp
+	return nil
+}
+
+func (w *Writer) ensureTable(ctx context.Context, tx ducklakeExecer, schema, table string, columns []wal.Column) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s.%s", quoteIdent(w.catalogName), quoteIdent(schema))); err != nil {
+		return fmt.Errorf("create ducklake schema: %w", err)
+	}
+	stmt := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", qname(w.catalogName, schema, table), columnDDL(columns))
+	if _, err := tx.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("create ducklake table: %w", err)
+	}
+	return nil
+}
+
+func (w *Writer) stageRowsAndInsert(ctx context.Context, conn *sql.Conn, buf *tableBuffer) error {
+	cols := columnList(buf.Columns)
+	stmt := fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM sb_rows", qname(w.catalogName, buf.Schema, buf.Table), cols, cols)
+	return appendQuery(ctx, conn, stmt, "sb_rows", buf.Columns, buf.Rows)
+}
+
+func (w *Writer) stageDeletesAndApply(ctx context.Context, conn *sql.Conn, buf *tableBuffer) error {
+	keys := keyColumns(buf.Columns, buf.KeyColumns)
+	if len(keys) == 0 {
+		return nil
+	}
+	stmt := fmt.Sprintf("DELETE FROM %s AS t USING sb_keys AS k WHERE %s", qname(w.catalogName, buf.Schema, buf.Table), keyPredicate("t", "k", keys))
+	return appendQuery(ctx, conn, stmt, "sb_keys", keys, buf.Deletes)
+}
+
+func appendQuery(ctx context.Context, conn *sql.Conn, query, table string, columns []wal.Column, rows [][]cell) error {
+	types, err := typeInfos(columns)
+	if err != nil {
+		return err
+	}
+	names := columnNames(columns)
+	return conn.Raw(func(raw any) error {
+		driverConn, ok := raw.(driver.Conn)
+		if !ok {
+			return fmt.Errorf("duckdb raw connection has unexpected type %T", raw)
+		}
+		appender, err := duckdb.NewQueryAppender(driverConn, query, table, types, names)
+		if err != nil {
+			return err
+		}
+		closed := false
+		defer func() {
+			if !closed {
+				_ = appender.Clear()
+				_ = appender.Close()
+			}
+		}()
+		for _, row := range rows {
+			values, err := rowValues(columns, row)
+			if err != nil {
+				return err
+			}
+			if err := appender.AppendRow(values...); err != nil {
+				return err
+			}
+		}
+		if err := appender.CloseWithCancel(ctx); err != nil {
+			return err
+		}
+		closed = true
+		return nil
+	})
+}
+
+func rowValues(columns []wal.Column, row []cell) ([]driver.Value, error) {
+	values := make([]driver.Value, len(columns))
+	for i, col := range columns {
+		if i >= len(row) || row[i].IsNull {
+			values[i] = nil
+			continue
+		}
+		v, err := parseValue(col.OID, row[i].Data)
+		if err != nil {
+			return nil, fmt.Errorf("column %s: %w", col.Name, err)
+		}
+		values[i] = v
+	}
+	return values, nil
+}
+
+func (w *Writer) Truncate(ctx context.Context, event wal.RowEvent) error {
+	exists, err := w.tableExists(ctx, event.Schema, event.Table)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		w.logger.Info("ducklake truncate on not-yet-created table, no-op", "table", event.Schema+"."+event.Table)
+		return nil
+	}
+	tx, err := w.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", qname(w.catalogName, event.Schema, event.Table))); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := w.setCommitMessage(ctx, tx, event.Schema, event.Table, "truncate", event.WALStartLSN.String()); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if buf := w.buffers[event.Schema+"."+event.Table]; buf != nil {
+		buf.Rows = nil
+		buf.Deletes = nil
+		buf.FirstLSN = 0
+		buf.LastLSN = event.WALStartLSN
+	}
+	delete(w.ensuredTables, event.Schema+"."+event.Table)
+	return nil
+}
+
+func (w *Writer) applySchemaChanges(ctx context.Context, tx ducklakeExecer, rel *wal.RelationMessage, defaults map[string]string) error {
+	table := qname(w.catalogName, rel.Namespace, rel.Name)
+	for _, ch := range rel.Changes {
+		switch ch.Type {
+		case wal.SchemaChangeAdd:
+			stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, quoteIdent(ch.Column), pgOIDToDuckDBType(ch.NewOID))
+			if def := defaults[ch.Column]; def != "" && isSimpleDefault(def) {
+				stmt += " DEFAULT " + def
+			}
+			if _, err := tx.ExecContext(ctx, stmt); err != nil {
+				return fmt.Errorf("add ducklake column %s: %w", ch.Column, err)
+			}
+		case wal.SchemaChangeDrop:
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", table, quoteIdent(ch.Column))); err != nil {
+				return fmt.Errorf("drop ducklake column %s: %w", ch.Column, err)
+			}
+		case wal.SchemaChangeTypeChange:
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE %s", table, quoteIdent(ch.Column), pgOIDToDuckDBType(ch.NewOID))); err != nil {
+				return fmt.Errorf("alter ducklake column %s: %w", ch.Column, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (w *Writer) reconcileTableSchema(ctx context.Context, tx ducklakeQueryExecer, schema, table string, columns []wal.Column) error {
+	rows, err := tx.QueryContext(ctx,
+		"SELECT column_name FROM information_schema.columns WHERE table_catalog = ? AND table_schema = ? AND table_name = ?",
+		w.catalogName, schema, table,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	existing := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return err
+		}
+		existing[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	tableName := qname(w.catalogName, schema, table)
+	for _, col := range columns {
+		if existing[col.Name] {
+			continue
+		}
+		stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", tableName, quoteIdent(col.Name), pgOIDToDuckDBType(col.OID))
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("reconcile add ducklake column %s: %w", col.Name, err)
+		}
+	}
+	return nil
+}
+
+func isSimpleDefault(s string) bool {
+	if s == "" {
+		return false
+	}
+	upper := strings.ToUpper(s)
+	return !strings.Contains(upper, "NEXTVAL(") && !strings.ContainsAny(s, ";")
+}
+
+func (w *Writer) setCommitMessage(ctx context.Context, tx ducklakeExecer, schema, table, op, lsn string) error {
+	extra := map[string]any{
+		"streambed.table":   schema + "." + table,
+		"streambed.op":      op,
+		"streambed.version": "1",
+	}
+	if lsn != "" {
+		extra["streambed.last_flush_lsn"] = lsn
+	}
+	data, err := json.Marshal(extra)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, fmt.Sprintf("CALL %s.set_commit_message(?, ?, extra_info => ?)", quoteIdent(w.catalogName)),
+		"streambed", op+" "+schema+"."+table, string(data))
+	return err
+}
+
+func (w *Writer) setBatchCommitMessage(ctx context.Context, tx ducklakeExecer, tableLSNs map[string]string) error {
+	extra := map[string]any{
+		"streambed.op":      "flush",
+		"streambed.version": "1",
+		"streambed.tables":  tableLSNs,
+	}
+	data, err := json.Marshal(extra)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, fmt.Sprintf("CALL %s.set_commit_message(?, ?, extra_info => ?)", quoteIdent(w.catalogName)),
+		"streambed", fmt.Sprintf("flush %d tables", len(tableLSNs)), string(data))
+	return err
+}
+
+func (w *Writer) tableExists(ctx context.Context, schema, table string) (bool, error) {
+	var n int
+	err := w.db.QueryRowContext(ctx,
+		"SELECT count(*) FROM information_schema.tables WHERE table_catalog = ? AND table_schema = ? AND table_name = ?",
+		w.catalogName, schema, table,
+	).Scan(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func (w *Writer) GetTableFlushLSN(ctx context.Context, schema, table string) (string, bool, error) {
+	return GetTableFlushLSN(ctx, w.db, w.catalogName, schema, table)
+}
+
+func GetTableFlushLSN(ctx context.Context, db *sql.DB, catalogName, schema, table string) (string, bool, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("SELECT commit_extra_info FROM %s.snapshots() WHERE commit_extra_info IS NOT NULL ORDER BY snapshot_id DESC", quoteIdent(catalogName)))
+	if err != nil {
+		return "", false, err
+	}
+	defer rows.Close()
+	target := schema + "." + table
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return "", false, err
+		}
+		var extra map[string]any
+		if err := json.Unmarshal([]byte(raw), &extra); err != nil {
+			continue
+		}
+		if extra["streambed.table"] == target {
+			if lsn, ok := extra["streambed.last_flush_lsn"].(string); ok && lsn != "" {
+				return lsn, true, nil
+			}
+		}
+		if tables, ok := extra["streambed.tables"].(map[string]any); ok {
+			if lsn, ok := tables[target].(string); ok && lsn != "" {
+				return lsn, true, nil
+			}
+		}
+	}
+	return "", false, rows.Err()
+}

--- a/internal/ducklake/writer_benchmark_test.go
+++ b/internal/ducklake/writer_benchmark_test.go
@@ -32,23 +32,59 @@ func BenchmarkWriterOperationMatrix(b *testing.B) {
 		{"delete", 5000, 1},
 		{"delete", 1000, 4},
 	}
+	for _, store := range []string{"sqlite", "duckdb"} {
+		for _, tc := range cases {
+			name := fmt.Sprintf("catalog=%s/%s/rows=%d/tables=%d", store, tc.op, tc.rows, tc.tables)
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					benchDuckLakeOperation(b, store, tc.op, tc.rows, tc.tables)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkWriterDuckDBCatalogOperationMatrix(b *testing.B) {
+	cases := []struct {
+		op     string
+		rows   int
+		tables int
+	}{
+		{"insert", 100, 1},
+		{"insert", 1000, 1},
+		{"insert", 5000, 1},
+		{"insert", 1000, 4},
+		{"update", 100, 1},
+		{"update", 1000, 1},
+		{"update", 5000, 1},
+		{"update", 1000, 4},
+		{"delete", 100, 1},
+		{"delete", 1000, 1},
+		{"delete", 5000, 1},
+		{"delete", 1000, 4},
+	}
 	for _, tc := range cases {
 		name := fmt.Sprintf("%s/rows=%d/tables=%d", tc.op, tc.rows, tc.tables)
 		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				benchDuckLakeOperation(b, tc.op, tc.rows, tc.tables)
+				benchDuckLakeOperation(b, "duckdb", tc.op, tc.rows, tc.tables)
 			}
 		})
 	}
 }
 
-func benchDuckLakeOperation(b *testing.B, op string, rows, tables int) {
+func benchDuckLakeOperation(b *testing.B, catalogStore, op string, rows, tables int) {
 	b.Helper()
 	ctx := context.Background()
 	dir := b.TempDir()
+	catalogPath := filepath.Join(dir, "catalog.sqlite")
+	if catalogStore == "duckdb" {
+		catalogPath = filepath.Join(dir, "catalog.ducklake")
+	}
 	w, err := NewWriter(ctx, Config{
-		CatalogPath: filepath.Join(dir, "catalog.sqlite"),
-		DataPath:    filepath.Join(dir, "data") + "/",
+		CatalogPath:  catalogPath,
+		CatalogStore: catalogStore,
+		DataPath:     filepath.Join(dir, "data") + "/",
 	}, nil, rows*tables+1, time.Second, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
 	if err != nil {
 		b.Fatalf("NewWriter: %v", err)

--- a/internal/ducklake/writer_benchmark_test.go
+++ b/internal/ducklake/writer_benchmark_test.go
@@ -1,0 +1,156 @@
+package ducklake
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+func BenchmarkWriterOperationMatrix(b *testing.B) {
+	cases := []struct {
+		op     string
+		rows   int
+		tables int
+	}{
+		{"insert", 100, 1},
+		{"insert", 1000, 1},
+		{"insert", 5000, 1},
+		{"insert", 1000, 4},
+		{"update", 100, 1},
+		{"update", 1000, 1},
+		{"update", 5000, 1},
+		{"update", 1000, 4},
+		{"delete", 100, 1},
+		{"delete", 1000, 1},
+		{"delete", 5000, 1},
+		{"delete", 1000, 4},
+	}
+	for _, tc := range cases {
+		name := fmt.Sprintf("%s/rows=%d/tables=%d", tc.op, tc.rows, tc.tables)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				benchDuckLakeOperation(b, tc.op, tc.rows, tc.tables)
+			}
+		})
+	}
+}
+
+func benchDuckLakeOperation(b *testing.B, op string, rows, tables int) {
+	b.Helper()
+	ctx := context.Background()
+	dir := b.TempDir()
+	w, err := NewWriter(ctx, Config{
+		CatalogPath: filepath.Join(dir, "catalog.sqlite"),
+		DataPath:    filepath.Join(dir, "data") + "/",
+	}, nil, rows*tables+1, time.Second, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	if err != nil {
+		b.Fatalf("NewWriter: %v", err)
+	}
+	defer w.Close()
+	cols := []wal.Column{
+		{Name: "id", OID: 23, IsKey: true},
+		{Name: "name", OID: 25},
+		{Name: "amount", OID: 20},
+	}
+	if op == "update" || op == "delete" {
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, insertEvent(table, row, cols, mustBenchLSN(1))); err != nil {
+					b.Fatalf("seed insert: %v", err)
+				}
+			}
+		}
+		if err := w.FlushAll(ctx); err != nil {
+			b.Fatalf("seed flush: %v", err)
+		}
+	}
+	b.ResetTimer()
+	switch op {
+	case "insert":
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, insertEvent(table, row, cols, mustBenchLSN(2))); err != nil {
+					b.Fatalf("insert event: %v", err)
+				}
+			}
+		}
+	case "update":
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, updateEvent(table, row, cols, mustBenchLSN(3))); err != nil {
+					b.Fatalf("update event: %v", err)
+				}
+			}
+		}
+	case "delete":
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, deleteEvent(table, row, cols, mustBenchLSN(4))); err != nil {
+					b.Fatalf("delete event: %v", err)
+				}
+			}
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		b.Fatalf("flush: %v", err)
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rows*tables), "rows")
+	b.ReportMetric(float64(tables), "tables")
+}
+
+func insertEvent(table, row int, cols []wal.Column, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{
+		Schema:     "public",
+		Table:      fmt.Sprintf("bench_%d", table),
+		Columns:    cols,
+		KeyColumns: []int{0},
+		Op:         wal.OpInsert,
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))},
+			{Name: "name", OID: 25, Value: []byte(fmt.Sprintf("name_%d", row))},
+			{Name: "amount", OID: 20, Value: []byte(fmt.Sprintf("%d", row*10))},
+		},
+		WALStartLSN: lsn,
+	}
+}
+
+func updateEvent(table, row int, cols []wal.Column, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{
+		Schema:     "public",
+		Table:      fmt.Sprintf("bench_%d", table),
+		Columns:    cols,
+		KeyColumns: []int{0},
+		Op:         wal.OpUpdate,
+		OldKey:     []wal.ColumnValue{{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))}},
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))},
+			{Name: "name", OID: 25, Value: []byte(fmt.Sprintf("updated_%d", row))},
+			{Name: "amount", OID: 20, Value: []byte(fmt.Sprintf("%d", row*20))},
+		},
+		WALStartLSN: lsn,
+	}
+}
+
+func deleteEvent(table, row int, cols []wal.Column, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{
+		Schema:      "public",
+		Table:       fmt.Sprintf("bench_%d", table),
+		Columns:     cols,
+		KeyColumns:  []int{0},
+		Op:          wal.OpDelete,
+		OldKey:      []wal.ColumnValue{{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))}},
+		WALStartLSN: lsn,
+	}
+}
+
+func mustBenchLSN(n int) pglogrepl.LSN {
+	return pglogrepl.LSN(n)
+}

--- a/internal/ducklake/writer_test.go
+++ b/internal/ducklake/writer_test.go
@@ -1,0 +1,226 @@
+package ducklake
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+func newTestWriter(t *testing.T) *Writer {
+	t.Helper()
+	dir := t.TempDir()
+	w, err := NewWriter(context.Background(), Config{
+		CatalogPath: filepath.Join(dir, "catalog.sqlite"),
+		DataPath:    filepath.Join(dir, "data") + "/",
+	}, nil, 100, time.Second, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	t.Cleanup(func() { w.Close() })
+	return w
+}
+
+func TestWriterInsertUpdateDeleteAndLSN(t *testing.T) {
+	ctx := context.Background()
+	w := newTestWriter(t)
+	cols := []wal.Column{
+		{Name: "id", OID: 23, IsKey: true},
+		{Name: "name", OID: 25},
+		{Name: "amount", OID: 20},
+	}
+	lsn1 := mustLSN(t, "0/10")
+	for _, row := range [][]string{{"1", "alice", "100"}, {"2", "bob", "200"}} {
+		if _, err := w.HandleEvent(ctx, wal.RowEvent{
+			Schema:     "public",
+			Table:      "orders",
+			Columns:    cols,
+			KeyColumns: []int{0},
+			Op:         wal.OpInsert,
+			Values: []wal.ColumnValue{
+				{Name: "id", OID: 23, Value: []byte(row[0])},
+				{Name: "name", OID: 25, Value: []byte(row[1])},
+				{Name: "amount", OID: 20, Value: []byte(row[2])},
+			},
+			WALStartLSN: lsn1,
+		}); err != nil {
+			t.Fatalf("insert event: %v", err)
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("flush inserts: %v", err)
+	}
+
+	lsn2 := mustLSN(t, "0/20")
+	if _, err := w.HandleEvent(ctx, wal.RowEvent{
+		Schema:     "public",
+		Table:      "orders",
+		Columns:    cols,
+		KeyColumns: []int{0},
+		Op:         wal.OpUpdate,
+		OldKey:     []wal.ColumnValue{{Name: "id", OID: 23, Value: []byte("1")}},
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte("1")},
+			{Name: "name", OID: 25, Value: []byte("ann")},
+			{Name: "amount", OID: 20, Value: []byte("125")},
+		},
+		WALStartLSN: lsn2,
+	}); err != nil {
+		t.Fatalf("update event: %v", err)
+	}
+	if _, err := w.HandleEvent(ctx, wal.RowEvent{
+		Schema:      "public",
+		Table:       "orders",
+		Columns:     cols,
+		KeyColumns:  []int{0},
+		Op:          wal.OpDelete,
+		OldKey:      []wal.ColumnValue{{Name: "id", OID: 23, Value: []byte("2")}},
+		WALStartLSN: lsn2,
+	}); err != nil {
+		t.Fatalf("delete event: %v", err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("flush mutations: %v", err)
+	}
+
+	var count int
+	var name string
+	var amount int64
+	if err := w.db.QueryRowContext(ctx, `SELECT count(*), min(name), min(amount) FROM "streambed"."public"."orders"`).Scan(&count, &name, &amount); err != nil {
+		t.Fatalf("query ducklake table: %v", err)
+	}
+	if count != 1 || name != "ann" || amount != 125 {
+		t.Fatalf("got count=%d name=%q amount=%d, want 1 ann 125", count, name, amount)
+	}
+	lsn, found, err := w.GetTableFlushLSN(ctx, "public", "orders")
+	if err != nil {
+		t.Fatalf("GetTableFlushLSN: %v", err)
+	}
+	if !found || lsn != lsn2.String() {
+		t.Fatalf("got lsn=%q found=%v, want %q true", lsn, found, lsn2.String())
+	}
+}
+
+func TestWriterSchemaChangeAndTruncate(t *testing.T) {
+	ctx := context.Background()
+	w := newTestWriter(t)
+	cols := []wal.Column{{Name: "id", OID: 23, IsKey: true}}
+	if _, err := w.HandleEvent(ctx, wal.RowEvent{
+		Schema:      "public",
+		Table:       "events",
+		Columns:     cols,
+		KeyColumns:  []int{0},
+		Op:          wal.OpInsert,
+		Values:      []wal.ColumnValue{{Name: "id", OID: 23, Value: []byte("1")}},
+		WALStartLSN: mustLSN(t, "0/30"),
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	evolved := &wal.RelationMessage{
+		Namespace:        "public",
+		Name:             "events",
+		Columns:          []wal.Column{{Name: "id", OID: 23, IsKey: true}, {Name: "payload", OID: 25}},
+		KeyColumnIndexes: []int{0},
+		Changes:          []wal.SchemaChange{{Type: wal.SchemaChangeAdd, Column: "payload", NewOID: 25}},
+	}
+	if err := w.HandleSchemaChange(ctx, evolved, nil); err != nil {
+		t.Fatalf("schema change: %v", err)
+	}
+	if _, err := w.HandleEvent(ctx, wal.RowEvent{
+		Schema:     "public",
+		Table:      "events",
+		Columns:    evolved.Columns,
+		KeyColumns: []int{0},
+		Op:         wal.OpInsert,
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte("2")},
+			{Name: "payload", OID: 25, Value: []byte("hello")},
+		},
+		WALStartLSN: mustLSN(t, "0/40"),
+	}); err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("flush evolved: %v", err)
+	}
+	if err := w.Truncate(ctx, wal.RowEvent{Schema: "public", Table: "events", WALStartLSN: mustLSN(t, "0/50")}); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	var count int
+	if err := w.db.QueryRowContext(ctx, `SELECT count(*) FROM "streambed"."public"."events"`).Scan(&count); err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("got %d rows after truncate, want 0", count)
+	}
+}
+
+func TestWriterFlushAllBatchesTableLSNs(t *testing.T) {
+	ctx := context.Background()
+	w := newTestWriter(t)
+	cols := []wal.Column{
+		{Name: "id", OID: 23, IsKey: true},
+		{Name: "name", OID: 25},
+	}
+	lsnA := mustLSN(t, "0/60")
+	lsnB := mustLSN(t, "0/70")
+	for _, tc := range []struct {
+		table string
+		lsn   pglogrepl.LSN
+		id    string
+		name  string
+	}{
+		{table: "accounts", lsn: lsnA, id: "1", name: "ann"},
+		{table: "orders", lsn: lsnB, id: "2", name: "book"},
+	} {
+		if _, err := w.HandleEvent(ctx, wal.RowEvent{
+			Schema:     "public",
+			Table:      tc.table,
+			Columns:    cols,
+			KeyColumns: []int{0},
+			Op:         wal.OpInsert,
+			Values: []wal.ColumnValue{
+				{Name: "id", OID: 23, Value: []byte(tc.id)},
+				{Name: "name", OID: 25, Value: []byte(tc.name)},
+			},
+			WALStartLSN: tc.lsn,
+		}); err != nil {
+			t.Fatalf("insert %s: %v", tc.table, err)
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("batched flush: %v", err)
+	}
+	for _, tc := range []struct {
+		table string
+		lsn   pglogrepl.LSN
+	}{
+		{table: "accounts", lsn: lsnA},
+		{table: "orders", lsn: lsnB},
+	} {
+		lsn, found, err := w.GetTableFlushLSN(ctx, "public", tc.table)
+		if err != nil {
+			t.Fatalf("GetTableFlushLSN(%s): %v", tc.table, err)
+		}
+		if !found || lsn != tc.lsn.String() {
+			t.Fatalf("%s lsn=%q found=%v, want %q true", tc.table, lsn, found, tc.lsn.String())
+		}
+	}
+}
+
+func mustLSN(t *testing.T, s string) pglogrepl.LSN {
+	t.Helper()
+	lsn, err := pglogrepl.ParseLSN(s)
+	if err != nil {
+		t.Fatalf("parse LSN %q: %v", s, err)
+	}
+	return lsn
+}

--- a/internal/ducklake/writer_test.go
+++ b/internal/ducklake/writer_test.go
@@ -14,16 +14,56 @@ import (
 
 func newTestWriter(t *testing.T) *Writer {
 	t.Helper()
+	return newTestWriterWithCatalogStore(t, "sqlite")
+}
+
+func newTestWriterWithCatalogStore(t *testing.T, catalogStore string) *Writer {
+	t.Helper()
 	dir := t.TempDir()
+	catalogPath := filepath.Join(dir, "catalog.sqlite")
+	if catalogStore == "duckdb" {
+		catalogPath = filepath.Join(dir, "catalog.ducklake")
+	}
 	w, err := NewWriter(context.Background(), Config{
-		CatalogPath: filepath.Join(dir, "catalog.sqlite"),
-		DataPath:    filepath.Join(dir, "data") + "/",
+		CatalogPath:  catalogPath,
+		CatalogStore: catalogStore,
+		DataPath:     filepath.Join(dir, "data") + "/",
 	}, nil, 100, time.Second, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
 	if err != nil {
 		t.Fatalf("NewWriter: %v", err)
 	}
 	t.Cleanup(func() { w.Close() })
 	return w
+}
+
+func TestWriterDuckDBCatalog(t *testing.T) {
+	ctx := context.Background()
+	w := newTestWriterWithCatalogStore(t, "duckdb")
+	cols := []wal.Column{{Name: "id", OID: 23, IsKey: true}, {Name: "name", OID: 25}}
+	if _, err := w.HandleEvent(ctx, wal.RowEvent{
+		Schema:     "public",
+		Table:      "duckdb_catalog_orders",
+		Columns:    cols,
+		KeyColumns: []int{0},
+		Op:         wal.OpInsert,
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte("1")},
+			{Name: "name", OID: 25, Value: []byte("alice")},
+		},
+		WALStartLSN: mustLSN(t, "0/10"),
+	}); err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	var got string
+	if err := w.db.QueryRowContext(ctx, `SELECT name FROM "streambed"."public"."duckdb_catalog_orders" WHERE id = 1`).Scan(&got); err != nil {
+		t.Fatalf("query duckdb-catalog ducklake table: %v", err)
+	}
+	if got != "alice" {
+		t.Fatalf("got %q, want alice", got)
+	}
 }
 
 func TestWriterInsertUpdateDeleteAndLSN(t *testing.T) {

--- a/internal/iceberg/writer_benchmark_test.go
+++ b/internal/iceberg/writer_benchmark_test.go
@@ -1,0 +1,163 @@
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/viggy28/streambed/internal/state"
+	"github.com/viggy28/streambed/internal/storage"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+func BenchmarkWriterOperationMatrix(b *testing.B) {
+	cases := []struct {
+		op     string
+		rows   int
+		tables int
+	}{
+		{"insert", 100, 1},
+		{"insert", 1000, 1},
+		{"insert", 5000, 1},
+		{"insert", 1000, 4},
+		{"update", 100, 1},
+		{"update", 1000, 1},
+		{"update", 5000, 1},
+		{"update", 1000, 4},
+		{"delete", 100, 1},
+		{"delete", 1000, 1},
+		{"delete", 5000, 1},
+		{"delete", 1000, 4},
+	}
+	for _, tc := range cases {
+		name := fmt.Sprintf("%s/rows=%d/tables=%d", tc.op, tc.rows, tc.tables)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				benchIcebergOperation(b, tc.op, tc.rows, tc.tables)
+			}
+		})
+	}
+}
+
+func benchIcebergOperation(b *testing.B, op string, rows, tables int) {
+	b.Helper()
+	ctx := context.Background()
+	mem := storage.NewMemS3Client("test-bucket")
+	catalog := NewCatalog(mem, "test-bucket", "test-prefix")
+	store := benchStateStore(b)
+	w := NewWriter(catalog, mem, store, "bench_slot", rows*tables+1, time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	cols := benchIcebergColumns()
+	if op == "update" || op == "delete" {
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, benchIcebergInsertEvent(table, row, cols, pglogrepl.LSN(1))); err != nil {
+					b.Fatalf("seed insert: %v", err)
+				}
+			}
+		}
+		if err := w.FlushAll(ctx); err != nil {
+			b.Fatalf("seed flush: %v", err)
+		}
+	}
+	b.ResetTimer()
+	switch op {
+	case "insert":
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, benchIcebergInsertEvent(table, row, cols, pglogrepl.LSN(2))); err != nil {
+					b.Fatalf("insert event: %v", err)
+				}
+			}
+		}
+	case "update":
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, benchIcebergUpdateEvent(table, row, cols, pglogrepl.LSN(3))); err != nil {
+					b.Fatalf("update event: %v", err)
+				}
+			}
+		}
+	case "delete":
+		for table := 0; table < tables; table++ {
+			for row := 0; row < rows; row++ {
+				if _, err := w.HandleEvent(ctx, benchIcebergDeleteEvent(table, row, cols, pglogrepl.LSN(4))); err != nil {
+					b.Fatalf("delete event: %v", err)
+				}
+			}
+		}
+	}
+	if err := w.FlushAll(ctx); err != nil {
+		b.Fatalf("flush: %v", err)
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rows*tables), "rows")
+	b.ReportMetric(float64(tables), "tables")
+}
+
+func benchStateStore(b *testing.B) *state.Store {
+	b.Helper()
+	s, err := state.Open(filepath.Join(b.TempDir(), "state.db"))
+	if err != nil {
+		b.Fatalf("open state store: %v", err)
+	}
+	b.Cleanup(func() { s.Close() })
+	return s
+}
+
+func benchIcebergColumns() []wal.Column {
+	return []wal.Column{
+		{Name: "id", OID: 23, IsKey: true},
+		{Name: "name", OID: 25},
+		{Name: "amount", OID: 20},
+	}
+}
+
+func benchIcebergInsertEvent(table, row int, cols []wal.Column, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{
+		Schema:     "public",
+		Table:      fmt.Sprintf("bench_%d", table),
+		Columns:    cols,
+		KeyColumns: []int{0},
+		Op:         wal.OpInsert,
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))},
+			{Name: "name", OID: 25, Value: []byte(fmt.Sprintf("name_%d", row))},
+			{Name: "amount", OID: 20, Value: []byte(fmt.Sprintf("%d", row*10))},
+		},
+		WALStartLSN: lsn,
+	}
+}
+
+func benchIcebergUpdateEvent(table, row int, cols []wal.Column, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{
+		Schema:     "public",
+		Table:      fmt.Sprintf("bench_%d", table),
+		Columns:    cols,
+		KeyColumns: []int{0},
+		Op:         wal.OpUpdate,
+		OldKey:     []wal.ColumnValue{{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))}},
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))},
+			{Name: "name", OID: 25, Value: []byte(fmt.Sprintf("updated_%d", row))},
+			{Name: "amount", OID: 20, Value: []byte(fmt.Sprintf("%d", row*20))},
+		},
+		WALStartLSN: lsn,
+	}
+}
+
+func benchIcebergDeleteEvent(table, row int, cols []wal.Column, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{
+		Schema:      "public",
+		Table:       fmt.Sprintf("bench_%d", table),
+		Columns:     cols,
+		KeyColumns:  []int{0},
+		Op:          wal.OpDelete,
+		OldKey:      []wal.ColumnValue{{Name: "id", OID: 23, Value: []byte(fmt.Sprintf("%d", row+1))}},
+		WALStartLSN: lsn,
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/viggy28/streambed/internal/failpoint"
-	"github.com/viggy28/streambed/internal/iceberg"
 	"github.com/viggy28/streambed/internal/state"
 	"github.com/viggy28/streambed/internal/wal"
 )
@@ -20,8 +19,17 @@ const (
 	standbyTimeout = 10 * time.Second
 )
 
+// Writer is the durable sink used by the WAL pipeline. Iceberg and DuckLake
+// implementations both satisfy this small contract.
+type Writer interface {
+	HandleEvent(context.Context, wal.RowEvent) (bool, error)
+	HandleSchemaChange(context.Context, *wal.RelationMessage, map[string]string) error
+	FlushAll(context.Context) error
+	ComputePendingMinLSN() pglogrepl.LSN
+}
+
 // Pipeline is a single-goroutine sync engine that reads WAL events from
-// Postgres and writes them to S3/Iceberg. It replaces the previous
+// Postgres and writes them to a lakehouse sink. It replaces the previous
 // two-goroutine Consumer+Writer architecture, eliminating the channels
 // between them and simplifying ack bookkeeping.
 type Pipeline struct {
@@ -34,7 +42,7 @@ type Pipeline struct {
 	state         *state.Store
 	tableFlushLSN map[string]pglogrepl.LSN
 
-	writer        *iceberg.Writer
+	writer        Writer
 	metaQuerier   *wal.MetadataQuerier // for column default lookups on schema change
 	flushInterval time.Duration
 	logger        *slog.Logger
@@ -42,7 +50,7 @@ type Pipeline struct {
 
 // New creates a Pipeline that reads WAL from conn and flushes to the
 // provided Writer. tableFlushLSN is the per-table last flushed LSN read
-// from Iceberg at startup, keyed by "schema.table".
+// from the target lakehouse at startup, keyed by "schema.table".
 func New(
 	conn *pgconn.PgConn,
 	slotName, publication string,
@@ -51,7 +59,7 @@ func New(
 	logger *slog.Logger,
 	stateStore *state.Store,
 	tableFlushLSN map[string]pglogrepl.LSN,
-	writer *iceberg.Writer,
+	writer Writer,
 	flushInterval time.Duration,
 	metaQuerier *wal.MetadataQuerier,
 ) *Pipeline {

--- a/internal/server/ducklake_test.go
+++ b/internal/server/ducklake_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/viggy28/streambed/internal/ducklake"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+func TestDuckLakeServerRegistersViews(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	catalogPath := filepath.Join(dir, "catalog.sqlite")
+	dataPath := filepath.Join(dir, "data") + "/"
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	writer, err := ducklake.NewWriter(ctx, ducklake.Config{
+		CatalogPath: catalogPath,
+		DataPath:    dataPath,
+	}, nil, 10, time.Second, logger)
+	if err != nil {
+		t.Fatalf("ducklake writer: %v", err)
+	}
+	_, err = writer.HandleEvent(ctx, wal.RowEvent{
+		Schema:     "public",
+		Table:      "orders",
+		Columns:    []wal.Column{{Name: "id", OID: 23, IsKey: true}, {Name: "name", OID: 25}},
+		KeyColumns: []int{0},
+		Op:         wal.OpInsert,
+		Values: []wal.ColumnValue{
+			{Name: "id", OID: 23, Value: []byte("1")},
+			{Name: "name", OID: 25, Value: []byte("alice")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handle event: %v", err)
+	}
+	if err := writer.FlushAll(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	srv, err := NewServer(ServerConfig{
+		ListenAddr:       ":0",
+		TargetFormat:     "ducklake",
+		DuckLakeCatalog:  catalogPath,
+		DuckLakeDataPath: dataPath,
+	}, nil, logger)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer srv.Close()
+	if err := srv.refreshAndRegister(ctx); err != nil {
+		t.Fatalf("refreshAndRegister: %v", err)
+	}
+	var count int
+	if err := srv.duckDB.QueryRow(`SELECT count(*) FROM orders`).Scan(&count); err != nil {
+		t.Fatalf("query unqualified view: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("got count=%d, want 1", count)
+	}
+	if err := srv.duckDB.QueryRow(`SELECT count(*) FROM public_orders`).Scan(&count); err != nil {
+		t.Fatalf("query qualified view: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("got qualified count=%d, want 1", count)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,14 +18,15 @@ import (
 
 // ServerConfig holds configuration for the query server.
 type ServerConfig struct {
-	ListenAddr       string
-	S3Bucket         string
-	S3Prefix         string
-	S3Endpoint       string
-	S3Region         string
-	TargetFormat     string
-	DuckLakeCatalog  string
-	DuckLakeDataPath string
+	ListenAddr           string
+	S3Bucket             string
+	S3Prefix             string
+	S3Endpoint           string
+	S3Region             string
+	TargetFormat         string
+	DuckLakeCatalog      string
+	DuckLakeCatalogStore string
+	DuckLakeDataPath     string
 }
 
 // Server implements a Postgres-wire-compatible query interface backed by DuckDB.
@@ -50,10 +51,11 @@ func NewServer(cfg ServerConfig, s3Client storage.ObjectStorage, logger *slog.Lo
 	var catalog *TableCatalog
 	if cfg.TargetFormat == "ducklake" {
 		if err := ducklake.Configure(context.Background(), db, ducklake.Config{
-			CatalogPath: cfg.DuckLakeCatalog,
-			DataPath:    cfg.DuckLakeDataPath,
-			S3Endpoint:  cfg.S3Endpoint,
-			S3Region:    cfg.S3Region,
+			CatalogPath:  cfg.DuckLakeCatalog,
+			CatalogStore: cfg.DuckLakeCatalogStore,
+			DataPath:     cfg.DuckLakeDataPath,
+			S3Endpoint:   cfg.S3Endpoint,
+			S3Region:     cfg.S3Region,
 		}); err != nil {
 			db.Close()
 			return nil, fmt.Errorf("configure ducklake: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,16 +12,20 @@ import (
 	duckdb "github.com/duckdb/duckdb-go/v2"
 
 	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/viggy28/streambed/internal/ducklake"
 	"github.com/viggy28/streambed/internal/storage"
 )
 
 // ServerConfig holds configuration for the query server.
 type ServerConfig struct {
-	ListenAddr string
-	S3Bucket   string
-	S3Prefix   string
-	S3Endpoint string
-	S3Region   string
+	ListenAddr       string
+	S3Bucket         string
+	S3Prefix         string
+	S3Endpoint       string
+	S3Region         string
+	TargetFormat     string
+	DuckLakeCatalog  string
+	DuckLakeDataPath string
 }
 
 // Server implements a Postgres-wire-compatible query interface backed by DuckDB.
@@ -36,19 +40,34 @@ type Server struct {
 // NewServer creates a query server. Initializes an embedded DuckDB instance
 // configured with S3 credentials and loads the Iceberg + httpfs extensions.
 func NewServer(cfg ServerConfig, s3Client storage.ObjectStorage, logger *slog.Logger) (*Server, error) {
+	if cfg.TargetFormat == "" {
+		cfg.TargetFormat = "iceberg"
+	}
 	db, err := sql.Open("duckdb", "")
 	if err != nil {
 		return nil, fmt.Errorf("open duckdb: %w", err)
 	}
-	conn, _ := db.Conn(context.Background())
-	// configure DuckDB on a specific connection
-	configureDuckDBPerConn(context.Background(), conn, cfg)
-	if err := configureDuckDB(db, cfg); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("configure duckdb: %w", err)
+	var catalog *TableCatalog
+	if cfg.TargetFormat == "ducklake" {
+		if err := ducklake.Configure(context.Background(), db, ducklake.Config{
+			CatalogPath: cfg.DuckLakeCatalog,
+			DataPath:    cfg.DuckLakeDataPath,
+			S3Endpoint:  cfg.S3Endpoint,
+			S3Region:    cfg.S3Region,
+		}); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("configure ducklake: %w", err)
+		}
+	} else {
+		conn, _ := db.Conn(context.Background())
+		// configure DuckDB on a specific connection
+		configureDuckDBPerConn(context.Background(), conn, cfg)
+		if err := configureDuckDB(db, cfg); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("configure duckdb: %w", err)
+		}
+		catalog = NewTableCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix, logger)
 	}
-
-	catalog := NewTableCatalog(s3Client, cfg.S3Bucket, cfg.S3Prefix, logger)
 
 	return &Server{
 		cfg:     cfg,
@@ -290,6 +309,9 @@ func (s *Server) handleParse(ctx context.Context, query string) (wire.PreparedSt
 // If DuckDB's engine was invalidated by a FATAL error (e.g., corrupt Iceberg
 // table), it re-opens the DuckDB instance and retries view registration.
 func (s *Server) refreshAndRegister(ctx context.Context) error {
+	if s.cfg.TargetFormat == "ducklake" {
+		return s.registerDuckLakeViews(ctx)
+	}
 	if err := s.catalog.Refresh(ctx); err != nil {
 		return err
 	}
@@ -314,6 +336,49 @@ func (s *Server) refreshAndRegister(ctx context.Context) error {
 
 	// Retry view registration with the fresh engine.
 	return s.catalog.RegisterViews(s.duckDB)
+}
+
+func (s *Server) registerDuckLakeViews(ctx context.Context) error {
+	const catalogName = "streambed"
+	rows, err := s.duckDB.QueryContext(ctx,
+		"SELECT table_schema, table_name FROM information_schema.tables WHERE table_catalog = ? AND table_type = 'BASE TABLE'",
+		catalogName,
+	)
+	if err != nil {
+		return fmt.Errorf("list ducklake tables: %w", err)
+	}
+	defer rows.Close()
+	type tableInfo struct {
+		schema string
+		table  string
+	}
+	var tables []tableInfo
+	nameCount := map[string]int{}
+	for rows.Next() {
+		var info tableInfo
+		if err := rows.Scan(&info.schema, &info.table); err != nil {
+			return err
+		}
+		tables = append(tables, info)
+		nameCount[info.table]++
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, info := range tables {
+		src := fmt.Sprintf("%s.%s.%s", quoteIdent(catalogName), quoteIdent(info.schema), quoteIdent(info.table))
+		qualified := quoteIdent(info.schema + "_" + info.table)
+		if _, err := s.duckDB.ExecContext(ctx, fmt.Sprintf("CREATE OR REPLACE VIEW %s AS SELECT * FROM %s", qualified, src)); err != nil {
+			return fmt.Errorf("register ducklake view %s_%s: %w", info.schema, info.table, err)
+		}
+		if nameCount[info.table] == 1 {
+			if _, err := s.duckDB.ExecContext(ctx, fmt.Sprintf("CREATE OR REPLACE VIEW %s AS SELECT * FROM %s", quoteIdent(info.table), src)); err != nil {
+				return fmt.Errorf("register ducklake view %s: %w", info.table, err)
+			}
+		}
+	}
+	s.logger.Info("ducklake views registered", "count", len(tables))
+	return nil
 }
 
 // refreshLoop periodically refreshes the catalog and re-registers views.
@@ -388,4 +453,8 @@ func normalizeValue(v any) any {
 	default:
 		return v
 	}
+}
+
+func quoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 }

--- a/test/integration/ducklake_test.go
+++ b/test/integration/ducklake_test.go
@@ -1,0 +1,256 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/viggy28/streambed/internal/ducklake"
+	"github.com/viggy28/streambed/internal/pipeline"
+	"github.com/viggy28/streambed/internal/state"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+func TestDuckLakeEndToEndInsertUpdateDelete(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+
+	cleanup(t)
+	t.Cleanup(func() { cleanup(t) })
+	setupNamedTable(t, "ducklake_ops")
+	execSQL(t, "ALTER TABLE ducklake_ops REPLICA IDENTITY FULL")
+
+	statePath := t.TempDir() + "/state.db"
+	catalogPath := t.TempDir() + "/ducklake-catalog.sqlite"
+	dataPath := fmt.Sprintf("s3://%s/%s/ducklake-%d/", s3Bucket, s3Prefix, time.Now().UnixNano())
+
+	createSlotAndPublication(t)
+	insertNamedRows(t, "ducklake_ops", 100)
+	runDuckLakeSync(t, ctx, 12*time.Second, statePath, catalogPath, dataPath)
+
+	execSQL(t, "UPDATE ducklake_ops SET name = 'ducklake_updated', value = 42.42 WHERE id BETWEEN 1 AND 30")
+	execSQL(t, "DELETE FROM ducklake_ops WHERE id BETWEEN 31 AND 45")
+	insertNamedRows(t, "ducklake_ops", 25)
+	runDuckLakeSync(t, ctx, 12*time.Second, statePath, catalogPath, dataPath)
+
+	duckDB := newDuckLakeReader(t, catalogPath, dataPath)
+	defer duckDB.Close()
+	assertPgDuckLakeMatch(t, duckDB, "public", "ducklake_ops", []string{"id"}, []string{"id", "name", "value"})
+}
+
+func TestDuckLakeSchemaEvolutionAddColumn(t *testing.T) {
+	skipIfNotAvailable(t)
+	ctx := context.Background()
+
+	cleanup(t)
+	t.Cleanup(func() { cleanup(t) })
+	setupNamedTable(t, "ducklake_schema")
+
+	statePath := t.TempDir() + "/state.db"
+	catalogPath := t.TempDir() + "/ducklake-catalog.sqlite"
+	dataPath := fmt.Sprintf("s3://%s/%s/ducklake-schema-%d/", s3Bucket, s3Prefix, time.Now().UnixNano())
+
+	createSlotAndPublication(t)
+	insertNamedRows(t, "ducklake_schema", 10)
+	runDuckLakeSync(t, ctx, 12*time.Second, statePath, catalogPath, dataPath)
+
+	execSQL(t, "ALTER TABLE ducklake_schema ADD COLUMN extra_info TEXT")
+	execSQL(t, "INSERT INTO ducklake_schema (name, value, extra_info) VALUES ('after_schema', 9.99, 'extra')")
+	runDuckLakeSync(t, ctx, 12*time.Second, statePath, catalogPath, dataPath)
+
+	duckDB := newDuckLakeReader(t, catalogPath, dataPath)
+	defer duckDB.Close()
+	var got string
+	if err := duckDB.QueryRow(`SELECT extra_info FROM "streambed"."public"."ducklake_schema" WHERE name = 'after_schema'`).Scan(&got); err != nil {
+		t.Fatalf("query evolved ducklake table: %v", err)
+	}
+	if got != "extra" {
+		t.Fatalf("got extra_info=%q, want extra", got)
+	}
+}
+
+func runDuckLakeSync(t *testing.T, ctx context.Context, duration time.Duration, statePath, catalogPath, dataPath string) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	stateStore, err := state.Open(statePath)
+	if err != nil {
+		t.Fatalf("open state store: %v", err)
+	}
+	defer stateStore.Close()
+
+	writer, err := ducklake.NewWriter(ctx, ducklake.Config{
+		CatalogPath: catalogPath,
+		DataPath:    dataPath,
+		S3Endpoint:  minioEndpoint,
+		S3Region:    s3Region,
+	}, stateStore, flushRows, 5*time.Second, logger)
+	if err != nil {
+		t.Fatalf("create ducklake writer: %v", err)
+	}
+	defer writer.Close()
+
+	pgConn, err := pgconn.Connect(ctx, pgReplConnStr())
+	if err != nil {
+		t.Fatalf("connect to postgres for replication: %v", err)
+	}
+	defer pgConn.Close(context.Background())
+
+	if err := wal.CreatePublication(ctx, pgConn, slotName, nil, logger); err != nil {
+		t.Fatalf("create publication: %v", err)
+	}
+	slotLSN, err := wal.CreateOrReuseSlot(ctx, pgConn, slotName, logger)
+	if err != nil {
+		t.Fatalf("setup replication slot: %v", err)
+	}
+
+	tableFlushLSN := make(map[string]pglogrepl.LSN)
+	registeredTables, err := stateStore.GetRegisteredTables()
+	if err != nil {
+		t.Fatalf("get registered tables: %v", err)
+	}
+	for _, rt := range registeredTables {
+		lsnStr, found, err := writer.GetTableFlushLSN(ctx, rt.Schema, rt.Table)
+		if err != nil || !found {
+			continue
+		}
+		lsn, err := pglogrepl.ParseLSN(lsnStr)
+		if err != nil {
+			continue
+		}
+		tableFlushLSN[fmt.Sprintf("%s.%s", rt.Schema, rt.Table)] = lsn
+	}
+
+	startLSN := slotLSN
+	for _, lsn := range tableFlushLSN {
+		if lsn > startLSN {
+			startLSN = lsn
+		}
+	}
+
+	metaConn, err := pgx.Connect(ctx, pgConnStr())
+	if err != nil {
+		t.Fatalf("connect metadata: %v", err)
+	}
+	defer metaConn.Close(context.Background())
+
+	p := pipeline.New(pgConn, slotName, slotName, startLSN, nil,
+		logger, stateStore, tableFlushLSN, writer, 5*time.Second, wal.NewMetadataQuerier(metaConn))
+
+	syncCtx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+	pipelineErr := p.Run(syncCtx)
+	if pipelineErr != nil && syncCtx.Err() != nil {
+		t.Logf("pipeline stopped: %v", pipelineErr)
+	} else if pipelineErr != nil {
+		t.Fatalf("unexpected pipeline error: %v", pipelineErr)
+	}
+}
+
+func newDuckLakeReader(t *testing.T, catalogPath, dataPath string) *sql.DB {
+	t.Helper()
+	db, err := ducklake.Open(context.Background(), ducklake.Config{
+		CatalogPath: catalogPath,
+		DataPath:    dataPath,
+		S3Endpoint:  minioEndpoint,
+		S3Region:    s3Region,
+	})
+	if err != nil {
+		t.Fatalf("open ducklake reader: %v", err)
+	}
+	return db
+}
+
+func assertPgDuckLakeMatch(t *testing.T, duckDB *sql.DB, schema, table string, keyColumns, compareColumns []string) {
+	t.Helper()
+	pgRows := queryPgRows(t, schema, table, keyColumns)
+	dlRows := queryDuckLakeRows(t, duckDB, schema, table, keyColumns)
+	discs := diffRowSets(pgRows, dlRows, compareColumns)
+	if len(discs) == 0 {
+		t.Logf("ducklake oracle: %s.%s OK — %d rows match", schema, table, len(pgRows))
+		return
+	}
+	limit := len(discs)
+	if limit > 10 {
+		limit = 10
+	}
+	for _, d := range discs[:limit] {
+		t.Logf("  [%s] key=%s %s", d.Kind, d.Key, d.Details)
+	}
+	t.Fatalf("ducklake oracle: %s.%s FAILED — discrepancies=%d", schema, table, len(discs))
+}
+
+func queryDuckLakeRows(t *testing.T, duckDB *sql.DB, schema, table string, keyColumns []string) map[string]map[string]string {
+	t.Helper()
+	orderBy := strings.Join(keyColumns, ", ")
+	query := fmt.Sprintf(`SELECT * FROM "streambed".%s.%s ORDER BY %s`, quoteIdentLocal(schema), quoteIdentLocal(table), orderBy)
+	sqlRows, err := duckDB.Query(query)
+	if err != nil {
+		t.Fatalf("oracle: query ducklake %s.%s: %v", schema, table, err)
+	}
+	defer sqlRows.Close()
+
+	colNames, err := sqlRows.Columns()
+	if err != nil {
+		t.Fatalf("oracle: ducklake columns: %v", err)
+	}
+	keyIndices := make([]int, len(keyColumns))
+	for i, kc := range keyColumns {
+		found := false
+		for j, cn := range colNames {
+			if cn == kc {
+				keyIndices[i] = j
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("oracle: key column %q not found in ducklake result (columns: %v)", kc, colNames)
+		}
+	}
+	rows := make(map[string]map[string]string)
+	for sqlRows.Next() {
+		vals := make([]interface{}, len(colNames))
+		ptrs := make([]interface{}, len(colNames))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := sqlRows.Scan(ptrs...); err != nil {
+			t.Fatalf("oracle: scan ducklake row: %v", err)
+		}
+		rowMap := make(map[string]string, len(colNames))
+		for i, v := range vals {
+			if v == nil {
+				rowMap[colNames[i]] = "<NULL>"
+			} else {
+				rowMap[colNames[i]] = fmt.Sprintf("%v", v)
+			}
+		}
+		keyParts := make([]string, len(keyColumns))
+		for i, ki := range keyIndices {
+			keyParts[i] = rowMap[colNames[ki]]
+		}
+		compositeKey := strings.Join(keyParts, "|")
+		if err := addUniqueOracleRow(rows, compositeKey, rowMap); err != nil {
+			t.Fatalf("oracle: %v", err)
+		}
+	}
+	if err := sqlRows.Err(); err != nil {
+		t.Fatalf("oracle: ducklake rows iteration: %v", err)
+	}
+	return rows
+}
+
+func quoteIdentLocal(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}

--- a/test/integration/lakehouse_feature_benchmark_test.go
+++ b/test/integration/lakehouse_feature_benchmark_test.go
@@ -1,0 +1,463 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/viggy28/streambed/internal/ducklake"
+	"github.com/viggy28/streambed/internal/iceberg"
+	"github.com/viggy28/streambed/internal/pipeline"
+	"github.com/viggy28/streambed/internal/state"
+	"github.com/viggy28/streambed/internal/storage"
+	"github.com/viggy28/streambed/internal/wal"
+)
+
+type lakehouseBenchTarget struct {
+	Name            string `json:"name"`
+	Format          string `json:"format"`
+	DuckLakeCatalog string `json:"ducklake_catalog,omitempty"`
+	IcebergMutation string `json:"iceberg_mutation,omitempty"`
+}
+
+type lakehouseBenchScenario struct {
+	Name         string `json:"name"`
+	BaselineRows int    `json:"baseline_rows"`
+	InsertRows   int    `json:"insert_rows"`
+	UpdateRows   int    `json:"update_rows"`
+	DeleteRows   int    `json:"delete_rows"`
+	FlushRows    int    `json:"flush_rows"`
+}
+
+type lakehouseBenchHandle struct {
+	writer      pipeline.Writer
+	closeWriter func()
+	openQuery   func() (*sql.DB, string, func())
+}
+
+type lakehouseBenchQueryResult struct {
+	Name     string `json:"name"`
+	MedianMS int64  `json:"median_ms"`
+	P95MS    int64  `json:"p95_ms"`
+}
+
+type lakehouseBenchResult struct {
+	Target                 lakehouseBenchTarget        `json:"target"`
+	Scenario               lakehouseBenchScenario      `json:"scenario"`
+	BaselineLoadDurationMS int64                       `json:"baseline_load_duration_ms"`
+	WriteDurationMS        int64                       `json:"write_duration_ms"`
+	FlushCount             int                         `json:"flush_count"`
+	FinalRows              int64                       `json:"final_rows"`
+	DataObjects            int                         `json:"data_objects"`
+	DeleteObjects          int                         `json:"delete_objects"`
+	TotalObjects           int                         `json:"total_objects"`
+	TotalObjectBytes       int64                       `json:"total_object_bytes"`
+	Queries                []lakehouseBenchQueryResult `json:"queries"`
+}
+
+type lakehouseBenchReport struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Metadata      benchmarkMetadata      `json:"metadata"`
+	QueryRuns     int                    `json:"query_runs"`
+	Results       []lakehouseBenchResult `json:"results"`
+	Caveats       []string               `json:"caveats"`
+}
+
+type lakeBenchAggregate struct {
+	Rows, DistinctIDs, SumIDs, SumVersion, SumAmount int64
+}
+
+// TestLakehouseFeatureBenchmark is a feature-validation benchmark for the full
+// write + read loop. It writes deterministic CDC-like events directly through
+// each lakehouse writer, then times representative DuckDB reads against the
+// produced lake. Run with:
+//
+//	STREAMBED_RUN_LAKEHOUSE_FEATURE_BENCH=1 go test -tags integration -run TestLakehouseFeatureBenchmark -count=1 ./test/integration
+//
+// Optional knobs:
+//
+//	STREAMBED_LAKEHOUSE_BENCH_ROWS, STREAMBED_LAKEHOUSE_BENCH_QUERY_RUNS,
+//	STREAMBED_LAKEHOUSE_BENCH_OUTPUT, STREAMBED_LAKEHOUSE_BENCH_INCLUDE_MOR=1
+func TestLakehouseFeatureBenchmark(t *testing.T) {
+	if os.Getenv("STREAMBED_RUN_LAKEHOUSE_FEATURE_BENCH") != "1" {
+		t.Skip("set STREAMBED_RUN_LAKEHOUSE_FEATURE_BENCH=1 to run lakehouse feature benchmark")
+	}
+	skipIfMinIOUnavailable(t)
+
+	baselineRows := envInt(t, "STREAMBED_LAKEHOUSE_BENCH_ROWS", 10_000, 100)
+	queryRuns := envInt(t, "STREAMBED_LAKEHOUSE_BENCH_QUERY_RUNS", 7, 3)
+	flushRowsList := envIntList(t, "STREAMBED_LAKEHOUSE_BENCH_FLUSH_ROWS", []int{100, 500, 1000, 10000}, 1)
+	mutationRows := max(1, baselineRows/10)
+	var scenarios []lakehouseBenchScenario
+	for _, flushRows := range flushRowsList {
+		scenarios = append(scenarios,
+			lakehouseBenchScenario{Name: "append", BaselineRows: baselineRows, InsertRows: mutationRows, FlushRows: flushRows},
+			lakehouseBenchScenario{Name: "update-10pct", BaselineRows: baselineRows, UpdateRows: mutationRows, FlushRows: flushRows},
+			lakehouseBenchScenario{Name: "delete-10pct", BaselineRows: baselineRows, DeleteRows: mutationRows, FlushRows: flushRows},
+			lakehouseBenchScenario{Name: "mixed-append-update-delete", BaselineRows: baselineRows, InsertRows: mutationRows, UpdateRows: mutationRows, DeleteRows: mutationRows, FlushRows: flushRows},
+		)
+	}
+	targets := []lakehouseBenchTarget{
+		{Name: "iceberg-cow", Format: "iceberg", IcebergMutation: string(iceberg.MutationModeCOW)},
+		{Name: "ducklake-sqlite", Format: "ducklake", DuckLakeCatalog: "sqlite"},
+		{Name: "ducklake-duckdb", Format: "ducklake", DuckLakeCatalog: "duckdb"},
+	}
+	if os.Getenv("STREAMBED_LAKEHOUSE_BENCH_INCLUDE_MOR") == "1" {
+		targets = append(targets, lakehouseBenchTarget{Name: "iceberg-mor", Format: "iceberg", IcebergMutation: string(iceberg.MutationModeMOR)})
+	}
+
+	ctx := context.Background()
+	var results []lakehouseBenchResult
+	for _, scenario := range scenarios {
+		for _, target := range targets {
+			t.Run(fmt.Sprintf("%s/%s/flush=%d", target.Name, scenario.Name, scenario.FlushRows), func(t *testing.T) {
+				result := runLakehouseFeatureBenchSample(t, ctx, target, scenario, queryRuns)
+				results = append(results, result)
+			})
+		}
+	}
+
+	report := lakehouseBenchReport{SchemaVersion: 1, Metadata: collectBenchmarkMetadata(1, 0, queryRuns), QueryRuns: queryRuns, Results: results, Caveats: []string{
+		"This benchmark bypasses Postgres logical replication and exercises writer + catalog commit + DuckDB reads only.",
+		"Baseline load is performed as one bulk flush and reported separately; write_duration_ms measures only the scenario workload at the configured flush_rows.",
+		"Iceberg and DuckLake write data to local MinIO; DuckLake catalog is local SQLite or DuckDB as configured.",
+		"Read timings include DuckDB query execution over the produced lake but do not include psql-wire server overhead.",
+	}}
+	encoded, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("lakehouse feature benchmark JSON:\n%s", encoded)
+	if out := os.Getenv("STREAMBED_LAKEHOUSE_BENCH_OUTPUT"); out != "" {
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(out, append(encoded, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func runLakehouseFeatureBenchSample(t *testing.T, ctx context.Context, target lakehouseBenchTarget, scenario lakehouseBenchScenario, queryRuns int) lakehouseBenchResult {
+	t.Helper()
+	objectStore, err := storage.NewS3Client(ctx, s3Bucket, s3Region, minioEndpoint)
+	if err != nil {
+		t.Fatalf("create S3 client: %v", err)
+	}
+	samplePrefix := path.Join(s3Prefix, "lakehouse-feature-bench", fmt.Sprintf("%d", time.Now().UnixNano()), target.Name, scenario.Name)
+	cleanupObjectPrefix(t, ctx, objectStore, samplePrefix)
+
+	stateStore, err := state.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	defer stateStore.Close()
+
+	logger := slog.New(slog.NewTextHandler(noopWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	model := newLakeBenchModel()
+	catalogPath := duckLakeBenchCatalogPath(t, target)
+
+	baselineHandle := newLakehouseBenchTarget(t, ctx, target, objectStore, stateStore, samplePrefix, catalogPath, scenario.BaselineRows+1, logger)
+	baselineStarted := time.Now()
+	writeBaselineEvents(t, ctx, baselineHandle.writer, scenario.BaselineRows, scenario.BaselineRows+1, model)
+	if err := baselineHandle.writer.FlushAll(ctx); err != nil {
+		t.Fatalf("baseline flush: %v", err)
+	}
+	baselineDuration := time.Since(baselineStarted)
+	baselineHandle.closeWriter()
+
+	handle := newLakehouseBenchTarget(t, ctx, target, objectStore, stateStore, samplePrefix, catalogPath, scenario.FlushRows, logger)
+	started := time.Now()
+	if scenario.InsertRows > 0 || scenario.UpdateRows > 0 || scenario.DeleteRows > 0 {
+		writeMutationEvents(t, ctx, handle.writer, scenario, model)
+	}
+	if err := handle.writer.FlushAll(ctx); err != nil {
+		t.Fatalf("final flush: %v", err)
+	}
+	writeDuration := time.Since(started)
+	handle.closeWriter()
+
+	queryDB, tableExpr, closeQuery := handle.openQuery()
+	defer closeQuery()
+	expected := model.aggregate()
+	validateLakehouseBenchSnapshot(t, queryDB, tableExpr, expected)
+	queries := runLakehouseBenchQueries(t, queryDB, tableExpr, expected, queryRuns)
+	dataObjects, deleteObjects, totalObjects, totalBytes := lakehouseBenchObjectStats(t, ctx, objectStore, samplePrefix)
+
+	return lakehouseBenchResult{Target: target, Scenario: scenario, BaselineLoadDurationMS: baselineDuration.Milliseconds(), WriteDurationMS: writeDuration.Milliseconds(), FlushCount: int(math.Ceil(float64(scenarioMutationUnits(scenario)) / float64(scenario.FlushRows))), FinalRows: expected.Rows, DataObjects: dataObjects, DeleteObjects: deleteObjects, TotalObjects: totalObjects, TotalObjectBytes: totalBytes, Queries: queries}
+}
+
+func scenarioMutationUnits(scenario lakehouseBenchScenario) int {
+	return scenario.InsertRows + scenario.DeleteRows + 2*scenario.UpdateRows
+}
+
+func duckLakeBenchCatalogPath(t *testing.T, target lakehouseBenchTarget) string {
+	t.Helper()
+	if target.Format != "ducklake" {
+		return ""
+	}
+	if target.DuckLakeCatalog == "duckdb" {
+		return filepath.Join(t.TempDir(), "catalog.ducklake")
+	}
+	return filepath.Join(t.TempDir(), "catalog.sqlite")
+}
+
+func newLakehouseBenchTarget(t *testing.T, ctx context.Context, target lakehouseBenchTarget, s3Client storage.ObjectStorage, stateStore *state.Store, samplePrefix, catalogPath string, flushRows int, logger *slog.Logger) lakehouseBenchHandle {
+	t.Helper()
+	const schema, table = "public", "feature_bench"
+	switch target.Format {
+	case "iceberg":
+		catalog := iceberg.NewCatalog(s3Client, s3Bucket, path.Join(samplePrefix, "iceberg"))
+		writer := iceberg.NewWriter(catalog, s3Client, stateStore, slotName, flushRows, time.Hour, logger, iceberg.WithMutationMode(iceberg.MutationMode(target.IcebergMutation)))
+		tableExpr := fmt.Sprintf("iceberg_scan('s3://%s/%s/%s/%s/%s', allow_moved_paths = true)", s3Bucket, samplePrefix, "iceberg", schema, table)
+		return lakehouseBenchHandle{
+			writer:      writer,
+			closeWriter: func() {},
+			openQuery: func() (*sql.DB, string, func()) {
+				db := newTestDuckDB(t)
+				return db, tableExpr, func() {}
+			},
+		}
+	case "ducklake":
+		cfg := ducklake.Config{CatalogPath: catalogPath, CatalogStore: target.DuckLakeCatalog, DataPath: fmt.Sprintf("s3://%s/%s/ducklake-data/", s3Bucket, samplePrefix), S3Endpoint: minioEndpoint, S3Region: s3Region}
+		writer, err := ducklake.NewWriter(ctx, cfg, stateStore, flushRows, time.Hour, logger)
+		if err != nil {
+			t.Fatalf("ducklake writer: %v", err)
+		}
+		return lakehouseBenchHandle{
+			writer:      writer,
+			closeWriter: func() { _ = writer.Close() },
+			openQuery: func() (*sql.DB, string, func()) {
+				queryDB, err := ducklake.Open(ctx, cfg)
+				if err != nil {
+					t.Fatalf("ducklake query open: %v", err)
+				}
+				return queryDB, fmt.Sprintf("%s.%s.%s", quoteBenchIdent("streambed"), quoteBenchIdent(schema), quoteBenchIdent(table)), func() { _ = queryDB.Close() }
+			},
+		}
+	default:
+		t.Fatalf("unknown target format %q", target.Format)
+		return lakehouseBenchHandle{}
+	}
+}
+
+func writeBaselineEvents(t *testing.T, ctx context.Context, writer pipeline.Writer, rows, flushRows int, model *lakeBenchModel) {
+	t.Helper()
+	for id := 1; id <= rows; id++ {
+		model.upsert(int64(id), 0, int64(id*10))
+		if _, err := writer.HandleEvent(ctx, lakeInsertEvent(id, 0, int64(id*10), pglogrepl.LSN(id))); err != nil {
+			t.Fatalf("baseline insert %d: %v", id, err)
+		}
+		if id%flushRows == 0 {
+			if err := writer.FlushAll(ctx); err != nil {
+				t.Fatalf("baseline flush: %v", err)
+			}
+		}
+	}
+}
+
+func writeMutationEvents(t *testing.T, ctx context.Context, writer pipeline.Writer, scenario lakehouseBenchScenario, model *lakeBenchModel) {
+	t.Helper()
+	lsn := scenario.BaselineRows + 1
+	for id := 1; id <= scenario.UpdateRows; id++ {
+		amount := int64(id * 20)
+		model.upsert(int64(id), 1, amount)
+		if _, err := writer.HandleEvent(ctx, lakeUpdateEvent(id, 1, amount, pglogrepl.LSN(lsn))); err != nil {
+			t.Fatalf("update %d: %v", id, err)
+		}
+		lsn++
+	}
+	deleteStart := scenario.UpdateRows + 1
+	for id := deleteStart; id < deleteStart+scenario.DeleteRows; id++ {
+		model.delete(int64(id))
+		if _, err := writer.HandleEvent(ctx, lakeDeleteEvent(id, pglogrepl.LSN(lsn))); err != nil {
+			t.Fatalf("delete %d: %v", id, err)
+		}
+		lsn++
+	}
+	insertStart := scenario.BaselineRows + 1
+	for id := insertStart; id < insertStart+scenario.InsertRows; id++ {
+		amount := int64(id * 10)
+		model.upsert(int64(id), 0, amount)
+		if _, err := writer.HandleEvent(ctx, lakeInsertEvent(id, 0, amount, pglogrepl.LSN(lsn))); err != nil {
+			t.Fatalf("insert %d: %v", id, err)
+		}
+		lsn++
+	}
+}
+
+func lakeBenchColumns() []wal.Column {
+	return []wal.Column{{Name: "id", OID: 20, IsKey: true}, {Name: "version", OID: 20}, {Name: "amount", OID: 20}, {Name: "payload", OID: 25}}
+}
+
+func lakeInsertEvent(id, version int, amount int64, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{Schema: "public", Table: "feature_bench", Columns: lakeBenchColumns(), KeyColumns: []int{0}, Op: wal.OpInsert, Values: lakeBenchValues(id, version, amount), WALStartLSN: lsn}
+}
+
+func lakeUpdateEvent(id, version int, amount int64, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{Schema: "public", Table: "feature_bench", Columns: lakeBenchColumns(), KeyColumns: []int{0}, Op: wal.OpUpdate, OldKey: []wal.ColumnValue{{Name: "id", OID: 20, Value: []byte(strconv.Itoa(id))}}, Values: lakeBenchValues(id, version, amount), WALStartLSN: lsn}
+}
+
+func lakeDeleteEvent(id int, lsn pglogrepl.LSN) wal.RowEvent {
+	return wal.RowEvent{Schema: "public", Table: "feature_bench", Columns: lakeBenchColumns(), KeyColumns: []int{0}, Op: wal.OpDelete, OldKey: []wal.ColumnValue{{Name: "id", OID: 20, Value: []byte(strconv.Itoa(id))}}, WALStartLSN: lsn}
+}
+
+func lakeBenchValues(id, version int, amount int64) []wal.ColumnValue {
+	return []wal.ColumnValue{{Name: "id", OID: 20, Value: []byte(strconv.Itoa(id))}, {Name: "version", OID: 20, Value: []byte(strconv.Itoa(version))}, {Name: "amount", OID: 20, Value: []byte(strconv.FormatInt(amount, 10))}, {Name: "payload", OID: 25, Value: []byte(fmt.Sprintf("payload_%08d", id))}}
+}
+
+func validateLakehouseBenchSnapshot(t *testing.T, db *sql.DB, tableExpr string, expected lakeBenchAggregate) {
+	t.Helper()
+	var got lakeBenchAggregate
+	query := fmt.Sprintf(`SELECT count(*), count(DISTINCT id), COALESCE(sum(id), 0), COALESCE(sum(version), 0), COALESCE(sum(amount), 0) FROM %s`, tableExpr)
+	if err := db.QueryRow(query).Scan(&got.Rows, &got.DistinctIDs, &got.SumIDs, &got.SumVersion, &got.SumAmount); err != nil {
+		t.Fatalf("validate query: %v", err)
+	}
+	if got != expected || got.Rows != got.DistinctIDs {
+		t.Fatalf("snapshot mismatch: got=%+v expected=%+v", got, expected)
+	}
+}
+
+func runLakehouseBenchQueries(t *testing.T, db *sql.DB, tableExpr string, expected lakeBenchAggregate, runs int) []lakehouseBenchQueryResult {
+	t.Helper()
+	queries := []struct{ name, sql string }{
+		{"full_aggregate", fmt.Sprintf(`SELECT count(*), count(DISTINCT id), COALESCE(sum(amount), 0) FROM %s`, tableExpr)},
+		{"selective_range", fmt.Sprintf(`SELECT count(*), COALESCE(sum(amount), 0) FROM %s WHERE id BETWEEN %d AND %d`, tableExpr, max(1, int(expected.Rows)/4), max(1, int(expected.Rows)/4)+100)},
+		{"point_lookup", fmt.Sprintf(`SELECT id, version, amount FROM %s WHERE id = %d`, tableExpr, max(1, int(expected.Rows)/2))},
+		{"topn_ordered", fmt.Sprintf(`SELECT id, amount FROM %s ORDER BY amount DESC LIMIT 10`, tableExpr)},
+	}
+	out := make([]lakehouseBenchQueryResult, 0, len(queries))
+	for _, q := range queries {
+		durations := make([]time.Duration, 0, runs)
+		for i := 0; i < runs; i++ {
+			started := time.Now()
+			rows, err := db.Query(q.sql)
+			if err != nil {
+				t.Fatalf("%s query: %v", q.name, err)
+			}
+			for rows.Next() {
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("%s rows: %v", q.name, err)
+			}
+			rows.Close()
+			durations = append(durations, time.Since(started))
+		}
+		out = append(out, lakehouseBenchQueryResult{Name: q.name, MedianMS: durationPercentileMS(durations, 0.50), P95MS: durationPercentileMS(durations, 0.95)})
+	}
+	return out
+}
+
+type lakeBenchRow struct{ version, amount int64 }
+type lakeBenchModel struct{ rows map[int64]lakeBenchRow }
+
+func newLakeBenchModel() *lakeBenchModel { return &lakeBenchModel{rows: map[int64]lakeBenchRow{}} }
+func (m *lakeBenchModel) upsert(id, version, amount int64) {
+	m.rows[id] = lakeBenchRow{version: version, amount: amount}
+}
+func (m *lakeBenchModel) delete(id int64) { delete(m.rows, id) }
+func (m *lakeBenchModel) aggregate() lakeBenchAggregate {
+	var a lakeBenchAggregate
+	for id, row := range m.rows {
+		a.Rows++
+		a.DistinctIDs++
+		a.SumIDs += id
+		a.SumVersion += row.version
+		a.SumAmount += row.amount
+	}
+	return a
+}
+
+func lakehouseBenchObjectStats(t *testing.T, ctx context.Context, s3Client storage.ObjectStorage, prefix string) (dataObjects, deleteObjects, totalObjects int, totalBytes int64) {
+	t.Helper()
+	keys, err := s3Client.ListPrefix(ctx, prefix)
+	if err != nil {
+		t.Fatalf("list bench prefix: %v", err)
+	}
+	for _, key := range keys {
+		totalObjects++
+		obj, err := s3Client.GetObject(ctx, key)
+		if err == nil {
+			totalBytes += int64(len(obj))
+		}
+		if filepath.Ext(key) == ".parquet" {
+			dataObjects++
+		}
+		if filepath.Ext(key) == ".posdel" || filepath.Ext(key) == ".eqdel" || filepath.Ext(key) == ".delete" || strings.Contains(key, "delete") {
+			deleteObjects++
+		}
+	}
+	return
+}
+
+func cleanupObjectPrefix(t *testing.T, ctx context.Context, s3Client storage.ObjectStorage, prefix string) {
+	t.Helper()
+	t.Cleanup(func() {
+		keys, err := s3Client.ListPrefix(ctx, prefix)
+		if err == nil && len(keys) > 0 {
+			_ = s3Client.DeleteObjects(ctx, keys)
+		}
+	})
+}
+
+func skipIfMinIOUnavailable(t *testing.T) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", "localhost:9002", 2*time.Second)
+	if err != nil {
+		t.Skipf("MinIO not available at localhost:9002: %v", err)
+	}
+	_ = conn.Close()
+}
+
+func envInt(t *testing.T, key string, def, minValue int) int {
+	t.Helper()
+	if raw := os.Getenv(key); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < minValue {
+			t.Fatalf("%s must be >= %d, got %q", key, minValue, raw)
+		}
+		return v
+	}
+	return def
+}
+
+func envIntList(t *testing.T, key string, def []int, minValue int) []int {
+	t.Helper()
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		v, err := strconv.Atoi(part)
+		if err != nil || v < minValue {
+			t.Fatalf("%s entries must be >= %d, got %q", key, minValue, part)
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s must contain at least one integer", key)
+	}
+	return out
+}
+
+func quoteBenchIdent(s string) string { return `"` + s + `"` }


### PR DESCRIPTION
## Summary

Adds DuckLake as an additive target format via `--target-format=ducklake`, using DuckDB's `ducklake` extension with a separate SQLite catalog DB. Iceberg remains the default and its implementation path stays separate.

This PR also includes a DuckLake writer performance pass after initial benchmarking showed most latency came from row-by-row staging through `database/sql`.

## What Changed

- Added DuckLake config and CLI flags:
  - `--target-format=iceberg|ducklake`
  - `--ducklake-catalog`
  - `--ducklake-data-path`
- Added a new `internal/ducklake` writer/resync implementation backed by DuckDB extensions: `ducklake`, `sqlite`, `httpfs`.
- Uses DuckLake SQL DML for mutation handling: staged keys + `DELETE ... USING`, then staged rows + `INSERT ... SELECT`.
- Optimized DuckLake writer staging with DuckDB `QueryAppender` instead of one SQL insert per staged row.
- Batches `FlushAll` across multiple DuckLake tables into one transaction while preserving per-table resume LSN metadata.
- Adds table/schema reconciliation caching for DuckLake flushes.
- Adds focused DuckLake unit tests, query-server test, integration tests, and writer benchmark matrices.
- Adds a matching Iceberg writer benchmark matrix for local comparison.

## Benchmark Notes

These are writer microbenchmarks, not full pipeline benchmarks. Iceberg uses Streambed's handwritten Iceberg writer with in-memory object storage. DuckLake uses DuckDB's DuckLake extension with a local SQLite catalog and local data path. The goal is to compare writer-path overhead and verify real performance improvements without changing benchmark shape.

DuckLake before vs after optimization:

| Operation | Shape | Before | After | Speedup |
|---|---:|---:|---:|---:|
| insert | 100 rows, 1 table | 49.4 ms | 29.0 ms | 1.7x |
| insert | 1,000 rows, 1 table | 144.0 ms | 34.4 ms | 4.2x |
| insert | 5,000 rows, 1 table | 605.9 ms | 37.9 ms | 16.0x |
| insert | 1,000 rows x 4 tables | 634.8 ms | 39.9 ms | 15.9x |
| update | 100 rows, 1 table | 63.8 ms | 28.8 ms | 2.2x |
| update | 1,000 rows, 1 table | 258.5 ms | 30.5 ms | 8.5x |
| update | 5,000 rows, 1 table | 1.05 s | 38.2 ms | 27.5x |
| update | 1,000 rows x 4 tables | 881.0 ms | 42.1 ms | 20.9x |
| delete | 100 rows, 1 table | 34.3 ms | 16.8 ms | 2.0x |
| delete | 1,000 rows, 1 table | 113.2 ms | 16.9 ms | 6.7x |
| delete | 5,000 rows, 1 table | 474.5 ms | 19.3 ms | 24.6x |
| delete | 1,000 rows x 4 tables | 439.7 ms | 31.5 ms | 13.9x |

Interpretation: after switching to DuckDB appenders, row-count sensitivity mostly disappears. Remaining latency is dominated by fixed DuckLake transaction/catalog/snapshot work and per-table DML.

## Validation

- `go test ./config ./internal/...` passed.
- `go test ./internal/ducklake -count=1 -v` passed.
- `go test -run '^$' -bench 'BenchmarkWriterOperationMatrix' -benchtime=1x -count=5 ./internal/ducklake` passed.
- `go test -run '^$' -bench 'BenchmarkWriterOperationMatrix' -benchtime=1x -count=3 ./internal/iceberg` passed.
- `go build ./cmd/streambed` passed, with a non-fatal sandbox stat-cache warning writing under the normal Go module cache.

Earlier in the session, focused Docker-backed DuckLake integration tests passed before the performance pass. After the performance pass, Docker daemon access was blocked by the sandbox, so I could not rerun those integration tests locally.

Known baseline note: the broader existing integration suite has two Iceberg failures on `origin/main` as well: `TestFlushThresholdCreatesExpectedParquetAndMetadata` and `TestPostgresTypeRoundTripToIceberg`.