### PR TITLE
docs: add DuckLake vs Iceberg benchmark report

### DIFF
--- a/docs/benchmarks/ducklake-vs-iceberg.md
+++ b/docs/benchmarks/ducklake-vs-iceberg.md
@@ -1,0 +1,164 @@
+# DuckLake vs Iceberg CDC-style benchmark
+
+This benchmark compares Streambed's lakehouse writer/read path across:
+
+- Iceberg COW
+- DuckLake with SQLite catalog
+- DuckLake with DuckDB catalog
+
+The goal is to measure the workload that matters for Streambed: frequent CDC-like appends, updates, and deletes followed by DuckDB reads.
+
+## Benchmark harness
+
+Executable harness:
+
+```text
+test/integration/lakehouse_feature_benchmark_test.go
+```
+
+Run the benchmark with the integration stack:
+
+```bash
+docker compose -f test/integration/docker-compose.yml up -d --wait || true
+
+STREAMBED_RUN_LAKEHOUSE_FEATURE_BENCH=1 \
+STREAMBED_LAKEHOUSE_BENCH_ROWS=100000 \
+STREAMBED_LAKEHOUSE_BENCH_FLUSH_ROWS=100,500,1000,10000 \
+STREAMBED_LAKEHOUSE_BENCH_QUERY_RUNS=7 \
+STREAMBED_LAKEHOUSE_BENCH_OUTPUT=/tmp/streambed-bench/lakehouse-matrix-100k.json \
+go test -tags integration -run TestLakehouseFeatureBenchmark -count=1 ./test/integration -v
+```
+
+For long 1M runs, increase the Go test timeout:
+
+```bash
+STREAMBED_RUN_LAKEHOUSE_FEATURE_BENCH=1 \
+STREAMBED_LAKEHOUSE_BENCH_ROWS=1000000 \
+STREAMBED_LAKEHOUSE_BENCH_FLUSH_ROWS=500,1000,10000 \
+STREAMBED_LAKEHOUSE_BENCH_QUERY_RUNS=7 \
+STREAMBED_LAKEHOUSE_BENCH_OUTPUT=/tmp/streambed-bench/lakehouse-matrix-1m-500plus.json \
+go test -timeout 60m -tags integration -run TestLakehouseFeatureBenchmark -count=1 ./test/integration -v
+```
+
+## Workload
+
+For each target/scenario, the benchmark:
+
+1. Loads the baseline table in one bulk flush.
+2. Reopens the writer against the same target.
+3. Applies only the scenario workload at the configured `flush_rows`.
+4. Measures scenario `write_duration_ms` only, excluding baseline load.
+5. Opens a DuckDB read connection and validates the final snapshot.
+6. Runs each read query multiple times and records median/p95 latency.
+
+Table schema:
+
+```sql
+id BIGINT PRIMARY KEY,
+version BIGINT,
+amount BIGINT,
+payload VARCHAR
+```
+
+Scenarios:
+
+- `append`: insert 10% new rows
+- `update-10pct`: update 10% of existing rows
+- `delete-10pct`: delete 10% of existing rows
+- `mixed-append-update-delete`: append 10%, update 10%, delete 10%
+
+Read queries:
+
+- `full_aggregate`: full-table count/distinct/sum
+- `selective_range`: range predicate around the middle of the table
+- `point_lookup`: lookup by a single `id`
+- `topn_ordered`: `ORDER BY amount DESC LIMIT 10`
+
+## Caveats
+
+- This is not an end-to-end replication benchmark.
+- It bypasses PostgreSQL logical replication and psql-wire overhead.
+- It measures writer/catalog commit performance plus DuckDB reads over local MinIO.
+- Results are from a local Apple M3 Max development machine with a dirty git tree while the benchmark harness was under development. Use these as a baseline snapshot, not an absolute production claim.
+- The 1M / `flush=100` Iceberg COW matrix did not complete within the 90 minute test timeout; only DuckLake results are captured for that flush size.
+
+## Committed result snapshots
+
+Raw JSON outputs from this benchmark run are committed under:
+
+```text
+docs/benchmarks/results/ducklake-vs-iceberg-100k.json
+docs/benchmarks/results/ducklake-vs-iceberg-1m-flush500-plus.json
+docs/benchmarks/results/ducklake-vs-iceberg-1m-flush100-ducklake.json
+```
+
+Each JSON file includes environment metadata, scenario shape, write duration, object counts, total object bytes, and read latency medians/p95s.
+
+## Summary: 100k baseline rows
+
+Values are `write_duration_ms` with total object count in parentheses.
+
+| scenario | flush | iceberg-cow | ducklake-sqlite | ducklake-duckdb |
+|---|---:|---:|---:|---:|
+| append | 100 | 1,731 (406) | 770 (101) | 542 (101) |
+| append | 500 | 236 (86) | 189 (21) | 151 (21) |
+| append | 1,000 | 120 (46) | 120 (11) | 88 (11) |
+| append | 10,000 | 26 (10) | 40 (2) | 35 (2) |
+| update 10% | 100 | 34,334 (806) | 4,074 (401) | 3,798 (401) |
+| update 10% | 500 | 6,753 (166) | 851 (81) | 800 (81) |
+| update 10% | 1,000 | 3,322 (86) | 450 (41) | 421 (41) |
+| update 10% | 10,000 | 346 (14) | 82 (5) | 73 (5) |
+| delete 10% | 100 | 16,420 (406) | 1,502 (101) | 1,153 (101) |
+| delete 10% | 500 | 3,214 (86) | 362 (21) | 376 (21) |
+| delete 10% | 1,000 | 1,582 (46) | 190 (11) | 131 (11) |
+| delete 10% | 10,000 | 163 (10) | 44 (2) | 38 (2) |
+| mixed | 100 | 53,381 (1,606) | 6,991 (601) | 6,255 (601) |
+| mixed | 500 | 10,668 (326) | 1,473 (121) | 1,230 (121) |
+| mixed | 1,000 | 5,118 (166) | 735 (61) | 607 (61) |
+| mixed | 10,000 | 527 (22) | 122 (7) | 123 (7) |
+
+## Summary: 1M baseline rows
+
+Values are `write_duration_ms` with total object count in parentheses.
+
+| scenario | flush | iceberg-cow | ducklake-sqlite | ducklake-duckdb |
+|---|---:|---:|---:|---:|
+| append | 100 | — | 6,630 (1,005) | 5,597 (1,005) |
+| update 10% | 100 | — | 103,336 (4,005) | 97,904 (4,005) |
+| delete 10% | 100 | — | 29,966 (1,005) | 26,780 (1,005) |
+| mixed | 100 | — | 205,288 (6,005) | 196,791 (6,005) |
+| append | 500 | 4,468 (806) | 1,558 (205) | 1,206 (205) |
+| update 10% | 500 | 539,958 (1,606) | 14,277 (805) | 13,308 (805) |
+| delete 10% | 500 | 256,689 (806) | 5,639 (205) | 5,325 (205) |
+| mixed | 500 | 804,298 (3,206) | 29,479 (1,205) | 28,312 (1,205) |
+| append | 1,000 | 2,227 (406) | 955 (105) | 732 (105) |
+| update 10% | 1,000 | 269,344 (806) | 7,075 (405) | 6,576 (405) |
+| delete 10% | 1,000 | 128,079 (406) | 2,877 (105) | 2,724 (105) |
+| mixed | 1,000 | 399,228 (1,606) | 13,989 (605) | 13,576 (605) |
+| append | 10,000 | 242 (46) | 246 (15) | 208 (15) |
+| update 10% | 10,000 | 26,999 (86) | 891 (45) | 834 (45) |
+| delete 10% | 10,000 | 12,836 (46) | 416 (15) | 405 (15) |
+| mixed | 10,000 | 40,040 (166) | 1,792 (65) | 1,697 (65) |
+
+## Example read medians: 1M baseline, flush=1,000
+
+Values are median milliseconds across 7 query runs.
+
+| scenario | target | full agg | range | point | topN |
+|---|---|---:|---:|---:|---:|
+| append | iceberg-cow | 60 | 37 | 42 | 31 |
+| append | ducklake-sqlite | 10 | 4 | 3 | 8 |
+| append | ducklake-duckdb | 8 | 2 | 2 | 6 |
+| update 10% | iceberg-cow | 42 | 14 | 15 | 52 |
+| update 10% | ducklake-sqlite | 17 | 4 | 4 | 22 |
+| update 10% | ducklake-duckdb | 16 | 2 | 2 | 21 |
+| delete 10% | iceberg-cow | 36 | 12 | 14 | 48 |
+| delete 10% | ducklake-sqlite | 14 | 3 | 3 | 22 |
+| delete 10% | ducklake-duckdb | 12 | 3 | 2 | 20 |
+| mixed | iceberg-cow | 56 | 35 | 38 | 32 |
+| mixed | ducklake-sqlite | 24 | 4 | 4 | 27 |
+| mixed | ducklake-duckdb | 25 | 2 | 2 | 24 |
+
+## Takeaway
+
+With realistic small CDC flush sizes, DuckLake is materially faster than Iceberg COW for mutation-heavy workloads. DuckDB catalog is usually faster than SQLite catalog, especially for point/range reads and commit-heavy workloads. Iceberg remains useful for broad ecosystem interoperability, but DuckLake better matches Streambed's DuckDB-centered query path and small-batch CDC mutation workload.

--- a/docs/benchmarks/results/ducklake-vs-iceberg-100k.json
+++ b/docs/benchmarks/results/ducklake-vs-iceberg-100k.json
@@ -1,0 +1,2182 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "timestamp_utc": "2026-08-29T05:41:25Z",
+    "git_commit": "5ecbfb40e04cab78a43f7d3591479ccb203b6db5",
+    "git_dirty": true,
+    "go_version": "go1.26.1",
+    "os": "darwin",
+    "arch": "arm64",
+    "repetitions": 1,
+    "query_runs": 7
+  },
+  "query_runs": 7,
+  "results": [
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 182,
+      "write_duration_ms": 1731,
+      "flush_count": 100,
+      "final_rows": 110000,
+      "data_objects": 101,
+      "delete_objects": 0,
+      "total_objects": 406,
+      "total_object_bytes": 6670643,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 27,
+          "p95_ms": 29
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 24,
+          "p95_ms": 26
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 26,
+          "p95_ms": 30
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 26,
+          "p95_ms": 33
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 142,
+      "write_duration_ms": 770,
+      "flush_count": 100,
+      "final_rows": 110000,
+      "data_objects": 101,
+      "delete_objects": 0,
+      "total_objects": 101,
+      "total_object_bytes": 1468592,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 6,
+          "p95_ms": 6
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 8,
+          "p95_ms": 10
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 125,
+      "write_duration_ms": 542,
+      "flush_count": 100,
+      "final_rows": 110000,
+      "data_objects": 101,
+      "delete_objects": 0,
+      "total_objects": 101,
+      "total_object_bytes": 1468009,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 5,
+          "p95_ms": 6
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 153,
+      "write_duration_ms": 34334,
+      "flush_count": 200,
+      "final_rows": 100000,
+      "data_objects": 201,
+      "delete_objects": 0,
+      "total_objects": 806,
+      "total_object_bytes": 285538751,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 12
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 141,
+      "write_duration_ms": 4074,
+      "flush_count": 200,
+      "final_rows": 100000,
+      "data_objects": 401,
+      "delete_objects": 200,
+      "total_objects": 401,
+      "total_object_bytes": 6155804,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 11,
+          "p95_ms": 13
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 17,
+          "p95_ms": 21
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 127,
+      "write_duration_ms": 3798,
+      "flush_count": 200,
+      "final_rows": 100000,
+      "data_objects": 401,
+      "delete_objects": 200,
+      "total_objects": 401,
+      "total_object_bytes": 6164277,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 5,
+          "p95_ms": 11
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 5,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 16
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 167,
+      "write_duration_ms": 16420,
+      "flush_count": 100,
+      "final_rows": 90000,
+      "data_objects": 101,
+      "delete_objects": 406,
+      "total_objects": 406,
+      "total_object_bytes": 132475493,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 12,
+          "p95_ms": 13
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 142,
+      "write_duration_ms": 1502,
+      "flush_count": 100,
+      "final_rows": 90000,
+      "data_objects": 101,
+      "delete_objects": 101,
+      "total_objects": 101,
+      "total_object_bytes": 3483707,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 8,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 16
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 127,
+      "write_duration_ms": 1153,
+      "flush_count": 100,
+      "final_rows": 90000,
+      "data_objects": 101,
+      "delete_objects": 101,
+      "total_objects": 101,
+      "total_object_bytes": 3484849,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 5,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 5,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 11,
+          "p95_ms": 12
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 150,
+      "write_duration_ms": 53381,
+      "flush_count": 400,
+      "final_rows": 100000,
+      "data_objects": 401,
+      "delete_objects": 1606,
+      "total_objects": 1606,
+      "total_object_bytes": 467472451,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 29,
+          "p95_ms": 32
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 25,
+          "p95_ms": 27
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 29,
+          "p95_ms": 31
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 29,
+          "p95_ms": 31
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 137,
+      "write_duration_ms": 6991,
+      "flush_count": 400,
+      "final_rows": 100000,
+      "data_objects": 601,
+      "delete_objects": 601,
+      "total_objects": 601,
+      "total_object_bytes": 12670867,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 13,
+          "p95_ms": 14
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 18,
+          "p95_ms": 18
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 133,
+      "write_duration_ms": 6255,
+      "flush_count": 400,
+      "final_rows": 100000,
+      "data_objects": 601,
+      "delete_objects": 601,
+      "total_objects": 601,
+      "total_object_bytes": 12711821,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 12,
+          "p95_ms": 12
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 15,
+          "p95_ms": 15
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 165,
+      "write_duration_ms": 236,
+      "flush_count": 20,
+      "final_rows": 110000,
+      "data_objects": 21,
+      "delete_objects": 0,
+      "total_objects": 86,
+      "total_object_bytes": 1839278,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 13,
+          "p95_ms": 14
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 10,
+          "p95_ms": 18
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 9,
+          "p95_ms": 11
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 135,
+      "write_duration_ms": 189,
+      "flush_count": 20,
+      "final_rows": 110000,
+      "data_objects": 21,
+      "delete_objects": 0,
+      "total_objects": 21,
+      "total_object_bytes": 1408602,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 5,
+          "p95_ms": 8
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 6,
+          "p95_ms": 7
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 134,
+      "write_duration_ms": 151,
+      "flush_count": 20,
+      "final_rows": 110000,
+      "data_objects": 21,
+      "delete_objects": 0,
+      "total_objects": 21,
+      "total_object_bytes": 1410838,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 4,
+          "p95_ms": 4
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 167,
+      "write_duration_ms": 6753,
+      "flush_count": 40,
+      "final_rows": 100000,
+      "data_objects": 41,
+      "delete_objects": 0,
+      "total_objects": 166,
+      "total_object_bytes": 55420003,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 11
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 135,
+      "write_duration_ms": 851,
+      "flush_count": 40,
+      "final_rows": 100000,
+      "data_objects": 81,
+      "delete_objects": 40,
+      "total_objects": 81,
+      "total_object_bytes": 2314828,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 15,
+          "p95_ms": 17
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 127,
+      "write_duration_ms": 800,
+      "flush_count": 40,
+      "final_rows": 100000,
+      "data_objects": 81,
+      "delete_objects": 40,
+      "total_objects": 81,
+      "total_object_bytes": 2313943,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 5,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 5,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 11,
+          "p95_ms": 12
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 150,
+      "write_duration_ms": 3214,
+      "flush_count": 20,
+      "final_rows": 90000,
+      "data_objects": 21,
+      "delete_objects": 86,
+      "total_objects": 86,
+      "total_object_bytes": 26826385,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 9,
+          "p95_ms": 11
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 136,
+      "write_duration_ms": 362,
+      "flush_count": 20,
+      "final_rows": 90000,
+      "data_objects": 21,
+      "delete_objects": 21,
+      "total_objects": 21,
+      "total_object_bytes": 1715908,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 9,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 15
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 138,
+      "write_duration_ms": 376,
+      "flush_count": 20,
+      "final_rows": 90000,
+      "data_objects": 21,
+      "delete_objects": 21,
+      "total_objects": 21,
+      "total_object_bytes": 1714976,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 10
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 150,
+      "write_duration_ms": 10668,
+      "flush_count": 80,
+      "final_rows": 100000,
+      "data_objects": 81,
+      "delete_objects": 326,
+      "total_objects": 326,
+      "total_object_bytes": 83220894,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 13,
+          "p95_ms": 14
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 9,
+          "p95_ms": 11
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 10,
+          "p95_ms": 23
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 10
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 158,
+      "write_duration_ms": 1473,
+      "flush_count": 80,
+      "final_rows": 100000,
+      "data_objects": 121,
+      "delete_objects": 121,
+      "total_objects": 121,
+      "total_object_bytes": 3764807,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 8
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 21
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 131,
+      "write_duration_ms": 1230,
+      "flush_count": 80,
+      "final_rows": 100000,
+      "data_objects": 121,
+      "delete_objects": 121,
+      "total_objects": 121,
+      "total_object_bytes": 3726491,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 12
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 152,
+      "write_duration_ms": 120,
+      "flush_count": 10,
+      "final_rows": 110000,
+      "data_objects": 11,
+      "delete_objects": 0,
+      "total_objects": 46,
+      "total_object_bytes": 1614623,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 11,
+          "p95_ms": 12
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 8,
+          "p95_ms": 16
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 138,
+      "write_duration_ms": 120,
+      "flush_count": 10,
+      "final_rows": 110000,
+      "data_objects": 11,
+      "delete_objects": 0,
+      "total_objects": 11,
+      "total_object_bytes": 1399017,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 6,
+          "p95_ms": 6
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 142,
+      "write_duration_ms": 88,
+      "flush_count": 10,
+      "final_rows": 110000,
+      "data_objects": 11,
+      "delete_objects": 0,
+      "total_objects": 11,
+      "total_object_bytes": 1398810,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 4,
+          "p95_ms": 4
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 159,
+      "write_duration_ms": 3322,
+      "flush_count": 20,
+      "final_rows": 100000,
+      "data_objects": 21,
+      "delete_objects": 0,
+      "total_objects": 86,
+      "total_object_bytes": 28206701,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 12
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 11,
+          "p95_ms": 12
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 132,
+      "write_duration_ms": 450,
+      "flush_count": 20,
+      "final_rows": 100000,
+      "data_objects": 41,
+      "delete_objects": 20,
+      "total_objects": 41,
+      "total_object_bytes": 1860731,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 9,
+          "p95_ms": 31
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 15,
+          "p95_ms": 17
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 141,
+      "write_duration_ms": 421,
+      "flush_count": 20,
+      "final_rows": 100000,
+      "data_objects": 41,
+      "delete_objects": 20,
+      "total_objects": 41,
+      "total_object_bytes": 1865054,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 8
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 52
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 13,
+          "p95_ms": 15
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 153,
+      "write_duration_ms": 1582,
+      "flush_count": 10,
+      "final_rows": 90000,
+      "data_objects": 11,
+      "delete_objects": 46,
+      "total_objects": 46,
+      "total_object_bytes": 14008064,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 11
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 133,
+      "write_duration_ms": 190,
+      "flush_count": 10,
+      "final_rows": 90000,
+      "data_objects": 11,
+      "delete_objects": 11,
+      "total_objects": 11,
+      "total_object_bytes": 1500044,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 9,
+          "p95_ms": 11
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 15
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 139,
+      "write_duration_ms": 131,
+      "flush_count": 10,
+      "final_rows": 90000,
+      "data_objects": 11,
+      "delete_objects": 11,
+      "total_objects": 11,
+      "total_object_bytes": 1497799,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 13,
+          "p95_ms": 16
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 168,
+      "write_duration_ms": 5118,
+      "flush_count": 40,
+      "final_rows": 100000,
+      "data_objects": 41,
+      "delete_objects": 166,
+      "total_objects": 166,
+      "total_object_bytes": 41602261,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 11,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 8,
+          "p95_ms": 10
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 139,
+      "write_duration_ms": 735,
+      "flush_count": 40,
+      "final_rows": 100000,
+      "data_objects": 61,
+      "delete_objects": 61,
+      "total_objects": 61,
+      "total_object_bytes": 2640047,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 9,
+          "p95_ms": 11
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 16
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 131,
+      "write_duration_ms": 607,
+      "flush_count": 40,
+      "final_rows": 100000,
+      "data_objects": 61,
+      "delete_objects": 61,
+      "total_objects": 61,
+      "total_object_bytes": 2647991,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 12,
+          "p95_ms": 15
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 145,
+      "write_duration_ms": 26,
+      "flush_count": 1,
+      "final_rows": 110000,
+      "data_objects": 2,
+      "delete_objects": 0,
+      "total_objects": 10,
+      "total_object_bytes": 1484295,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 7,
+          "p95_ms": 8
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 145,
+      "write_duration_ms": 40,
+      "flush_count": 1,
+      "final_rows": 110000,
+      "data_objects": 2,
+      "delete_objects": 0,
+      "total_objects": 2,
+      "total_object_bytes": 1392911,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 5,
+          "p95_ms": 6
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 6,
+          "p95_ms": 7
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 134,
+      "write_duration_ms": 35,
+      "flush_count": 1,
+      "final_rows": 110000,
+      "data_objects": 2,
+      "delete_objects": 0,
+      "total_objects": 2,
+      "total_object_bytes": 1392542,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 4,
+          "p95_ms": 5
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 148,
+      "write_duration_ms": 346,
+      "flush_count": 2,
+      "final_rows": 100000,
+      "data_objects": 3,
+      "delete_objects": 0,
+      "total_objects": 14,
+      "total_object_bytes": 4013724,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 8
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 11,
+          "p95_ms": 11
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 136,
+      "write_duration_ms": 82,
+      "flush_count": 2,
+      "final_rows": 100000,
+      "data_objects": 5,
+      "delete_objects": 2,
+      "total_objects": 5,
+      "total_object_bytes": 1459879,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 16
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 10000,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 130,
+      "write_duration_ms": 73,
+      "flush_count": 2,
+      "final_rows": 100000,
+      "data_objects": 5,
+      "delete_objects": 2,
+      "total_objects": 5,
+      "total_object_bytes": 1459189,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 5,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 13,
+          "p95_ms": 14
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 148,
+      "write_duration_ms": 163,
+      "flush_count": 1,
+      "final_rows": 90000,
+      "data_objects": 2,
+      "delete_objects": 10,
+      "total_objects": 10,
+      "total_object_bytes": 2548324,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 12
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 134,
+      "write_duration_ms": 44,
+      "flush_count": 1,
+      "final_rows": 90000,
+      "data_objects": 2,
+      "delete_objects": 2,
+      "total_objects": 2,
+      "total_object_bytes": 1303956,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 8
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 17
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 100000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 10000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 137,
+      "write_duration_ms": 38,
+      "flush_count": 1,
+      "final_rows": 90000,
+      "data_objects": 2,
+      "delete_objects": 2,
+      "total_objects": 2,
+      "total_object_bytes": 1304729,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 7,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 5,
+          "p95_ms": 5
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 11,
+          "p95_ms": 11
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 161,
+      "write_duration_ms": 527,
+      "flush_count": 4,
+      "final_rows": 100000,
+      "data_objects": 5,
+      "delete_objects": 22,
+      "total_objects": 22,
+      "total_object_bytes": 5370030,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 7,
+          "p95_ms": 13
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 136,
+      "write_duration_ms": 122,
+      "flush_count": 4,
+      "final_rows": 100000,
+      "data_objects": 7,
+      "delete_objects": 7,
+      "total_objects": 7,
+      "total_object_bytes": 1673733,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 9,
+          "p95_ms": 10
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 13,
+          "p95_ms": 14
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 100000,
+        "insert_rows": 10000,
+        "update_rows": 10000,
+        "delete_rows": 10000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 127,
+      "write_duration_ms": 123,
+      "flush_count": 4,
+      "final_rows": 100000,
+      "data_objects": 7,
+      "delete_objects": 7,
+      "total_objects": 7,
+      "total_object_bytes": 1673046,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 45
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 10
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 8
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 14,
+          "p95_ms": 16
+        }
+      ]
+    }
+  ],
+  "caveats": [
+    "This benchmark bypasses Postgres logical replication and exercises writer + catalog commit + DuckDB reads only.",
+    "Baseline load is performed as one bulk flush and reported separately; write_duration_ms measures only the scenario workload at the configured flush_rows.",
+    "Iceberg and DuckLake write data to local MinIO; DuckLake catalog is local SQLite or DuckDB as configured.",
+    "Read timings include DuckDB query execution over the produced lake but do not include psql-wire server overhead."
+  ]
+}

--- a/docs/benchmarks/results/ducklake-vs-iceberg-1m-flush100-ducklake.json
+++ b/docs/benchmarks/results/ducklake-vs-iceberg-1m-flush100-ducklake.json
@@ -1,0 +1,382 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "timestamp_utc": "2026-08-29T08:21:00Z",
+    "git_commit": "5ecbfb40e04cab78a43f7d3591479ccb203b6db5",
+    "git_dirty": true,
+    "go_version": "go1.26.1",
+    "os": "darwin",
+    "arch": "arm64",
+    "repetitions": 1,
+    "query_runs": 7
+  },
+  "query_runs": 7,
+  "results": [
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1189,
+      "write_duration_ms": 6630,
+      "flush_count": 1000,
+      "final_rows": 1100000,
+      "data_objects": 1005,
+      "delete_objects": 0,
+      "total_objects": 1005,
+      "total_object_bytes": 14672929,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 21,
+          "p95_ms": 24
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 5,
+          "p95_ms": 6
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 30,
+          "p95_ms": 32
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1141,
+      "write_duration_ms": 5597,
+      "flush_count": 1000,
+      "final_rows": 1100000,
+      "data_objects": 1005,
+      "delete_objects": 0,
+      "total_objects": 1005,
+      "total_object_bytes": 14669822,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 19,
+          "p95_ms": 23
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 28,
+          "p95_ms": 30
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1191,
+      "write_duration_ms": 103336,
+      "flush_count": 2000,
+      "final_rows": 1000000,
+      "data_objects": 4005,
+      "delete_objects": 2000,
+      "total_objects": 4005,
+      "total_object_bytes": 438854392,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 44,
+          "p95_ms": 45
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 6,
+          "p95_ms": 7
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 6,
+          "p95_ms": 6
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 64,
+          "p95_ms": 71
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1164,
+      "write_duration_ms": 97904,
+      "flush_count": 2000,
+      "final_rows": 1000000,
+      "data_objects": 4005,
+      "delete_objects": 2000,
+      "total_objects": 4005,
+      "total_object_bytes": 438677101,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 38,
+          "p95_ms": 41
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 70,
+          "p95_ms": 77
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1181,
+      "write_duration_ms": 29966,
+      "flush_count": 1000,
+      "final_rows": 900000,
+      "data_objects": 1005,
+      "delete_objects": 1005,
+      "total_objects": 1005,
+      "total_object_bytes": 220032774,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 14,
+          "p95_ms": 17
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 22,
+          "p95_ms": 31
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1160,
+      "write_duration_ms": 26780,
+      "flush_count": 1000,
+      "final_rows": 900000,
+      "data_objects": 1005,
+      "delete_objects": 1005,
+      "total_objects": 1005,
+      "total_object_bytes": 220104027,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 13,
+          "p95_ms": 14
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 21,
+          "p95_ms": 23
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1160,
+      "write_duration_ms": 205288,
+      "flush_count": 4000,
+      "final_rows": 1000000,
+      "data_objects": 6005,
+      "delete_objects": 6005,
+      "total_objects": 6005,
+      "total_object_bytes": 1068436356,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 59,
+          "p95_ms": 73
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 7,
+          "p95_ms": 8
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 7,
+          "p95_ms": 7
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 99,
+          "p95_ms": 110
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 100
+      },
+      "baseline_load_duration_ms": 1188,
+      "write_duration_ms": 196791,
+      "flush_count": 4000,
+      "final_rows": 1000000,
+      "data_objects": 6005,
+      "delete_objects": 6005,
+      "total_objects": 6005,
+      "total_object_bytes": 1068912340,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 58,
+          "p95_ms": 264
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 97,
+          "p95_ms": 99
+        }
+      ]
+    }
+  ],
+  "caveats": [
+    "This benchmark bypasses Postgres logical replication and exercises writer + catalog commit + DuckDB reads only.",
+    "Baseline load is performed as one bulk flush and reported separately; write_duration_ms measures only the scenario workload at the configured flush_rows.",
+    "Iceberg and DuckLake write data to local MinIO; DuckLake catalog is local SQLite or DuckDB as configured.",
+    "Read timings include DuckDB query execution over the produced lake but do not include psql-wire server overhead."
+  ]
+}

--- a/docs/benchmarks/results/ducklake-vs-iceberg-1m-flush500-plus.json
+++ b/docs/benchmarks/results/ducklake-vs-iceberg-1m-flush500-plus.json
@@ -1,0 +1,1642 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "timestamp_utc": "2026-08-29T08:08:46Z",
+    "git_commit": "5ecbfb40e04cab78a43f7d3591479ccb203b6db5",
+    "git_dirty": true,
+    "go_version": "go1.26.1",
+    "os": "darwin",
+    "arch": "arm64",
+    "repetitions": 1,
+    "query_runs": 7
+  },
+  "query_runs": 7,
+  "results": [
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1334,
+      "write_duration_ms": 4468,
+      "flush_count": 200,
+      "final_rows": 1100000,
+      "data_objects": 201,
+      "delete_objects": 0,
+      "total_objects": 806,
+      "total_object_bytes": 33463703,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 73,
+          "p95_ms": 75
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 46,
+          "p95_ms": 49
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 51,
+          "p95_ms": 53
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 47,
+          "p95_ms": 49
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1155,
+      "write_duration_ms": 1558,
+      "flush_count": 200,
+      "final_rows": 1100000,
+      "data_objects": 205,
+      "delete_objects": 0,
+      "total_objects": 205,
+      "total_object_bytes": 14065110,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 14
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 10,
+          "p95_ms": 11
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1159,
+      "write_duration_ms": 1206,
+      "flush_count": 200,
+      "final_rows": 1100000,
+      "data_objects": 205,
+      "delete_objects": 0,
+      "total_objects": 205,
+      "total_object_bytes": 14071298,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 12
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 8,
+          "p95_ms": 8
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1320,
+      "write_duration_ms": 539958,
+      "flush_count": 400,
+      "final_rows": 1000000,
+      "data_objects": 401,
+      "delete_objects": 0,
+      "total_objects": 1606,
+      "total_object_bytes": 5385761955,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 38,
+          "p95_ms": 42
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 16,
+          "p95_ms": 19
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 17,
+          "p95_ms": 21
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 55,
+          "p95_ms": 57
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1173,
+      "write_duration_ms": 14277,
+      "flush_count": 400,
+      "final_rows": 1000000,
+      "data_objects": 805,
+      "delete_objects": 400,
+      "total_objects": 805,
+      "total_object_bytes": 96167233,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 20,
+          "p95_ms": 22
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 28,
+          "p95_ms": 35
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1155,
+      "write_duration_ms": 13308,
+      "flush_count": 400,
+      "final_rows": 1000000,
+      "data_objects": 805,
+      "delete_objects": 400,
+      "total_objects": 805,
+      "total_object_bytes": 96109253,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 18,
+          "p95_ms": 19
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 22,
+          "p95_ms": 27
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1389,
+      "write_duration_ms": 256689,
+      "flush_count": 200,
+      "final_rows": 900000,
+      "data_objects": 201,
+      "delete_objects": 806,
+      "total_objects": 806,
+      "total_object_bytes": 2549478797,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 36,
+          "p95_ms": 37
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 13,
+          "p95_ms": 16
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 14,
+          "p95_ms": 15
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 52,
+          "p95_ms": 53
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1175,
+      "write_duration_ms": 5639,
+      "flush_count": 200,
+      "final_rows": 900000,
+      "data_objects": 205,
+      "delete_objects": 205,
+      "total_objects": 205,
+      "total_object_bytes": 53458393,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 14,
+          "p95_ms": 17
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 22,
+          "p95_ms": 24
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1161,
+      "write_duration_ms": 5325,
+      "flush_count": 200,
+      "final_rows": 900000,
+      "data_objects": 205,
+      "delete_objects": 205,
+      "total_objects": 205,
+      "total_object_bytes": 53443385,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 14,
+          "p95_ms": 16
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 20,
+          "p95_ms": 22
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1328,
+      "write_duration_ms": 804298,
+      "flush_count": 800,
+      "final_rows": 1000000,
+      "data_objects": 801,
+      "delete_objects": 3206,
+      "total_objects": 3206,
+      "total_object_bytes": 8123992880,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 77,
+          "p95_ms": 84
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 53,
+          "p95_ms": 55
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 56,
+          "p95_ms": 68
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 53,
+          "p95_ms": 63
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1177,
+      "write_duration_ms": 29479,
+      "flush_count": 800,
+      "final_rows": 1000000,
+      "data_objects": 1205,
+      "delete_objects": 1205,
+      "total_objects": 1205,
+      "total_object_bytes": 219642312,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 27,
+          "p95_ms": 28
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 35,
+          "p95_ms": 38
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 500
+      },
+      "baseline_load_duration_ms": 1222,
+      "write_duration_ms": 28312,
+      "flush_count": 800,
+      "final_rows": 1000000,
+      "data_objects": 1205,
+      "delete_objects": 1205,
+      "total_objects": 1205,
+      "total_object_bytes": 219643959,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 25,
+          "p95_ms": 30
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 32,
+          "p95_ms": 35
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1405,
+      "write_duration_ms": 2227,
+      "flush_count": 100,
+      "final_rows": 1100000,
+      "data_objects": 101,
+      "delete_objects": 0,
+      "total_objects": 406,
+      "total_object_bytes": 19803595,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 60,
+          "p95_ms": 101
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 37,
+          "p95_ms": 43
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 42,
+          "p95_ms": 43
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 31,
+          "p95_ms": 34
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1194,
+      "write_duration_ms": 955,
+      "flush_count": 100,
+      "final_rows": 1100000,
+      "data_objects": 105,
+      "delete_objects": 0,
+      "total_objects": 105,
+      "total_object_bytes": 13989414,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 10,
+          "p95_ms": 11
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 8,
+          "p95_ms": 9
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1170,
+      "write_duration_ms": 732,
+      "flush_count": 100,
+      "final_rows": 1100000,
+      "data_objects": 105,
+      "delete_objects": 0,
+      "total_objects": 105,
+      "total_object_bytes": 14047907,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 8
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 6,
+          "p95_ms": 7
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1350,
+      "write_duration_ms": 269344,
+      "flush_count": 200,
+      "final_rows": 1000000,
+      "data_objects": 201,
+      "delete_objects": 0,
+      "total_objects": 806,
+      "total_object_bytes": 2682187252,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 42,
+          "p95_ms": 45
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 14,
+          "p95_ms": 18
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 15,
+          "p95_ms": 18
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 52,
+          "p95_ms": 54
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1146,
+      "write_duration_ms": 7075,
+      "flush_count": 200,
+      "final_rows": 1000000,
+      "data_objects": 405,
+      "delete_objects": 200,
+      "total_objects": 405,
+      "total_object_bytes": 54908079,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 17,
+          "p95_ms": 19
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 22,
+          "p95_ms": 28
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1215,
+      "write_duration_ms": 6576,
+      "flush_count": 200,
+      "final_rows": 1000000,
+      "data_objects": 405,
+      "delete_objects": 200,
+      "total_objects": 405,
+      "total_object_bytes": 54927664,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 16,
+          "p95_ms": 19
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 21,
+          "p95_ms": 26
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1326,
+      "write_duration_ms": 128079,
+      "flush_count": 100,
+      "final_rows": 900000,
+      "data_objects": 101,
+      "delete_objects": 406,
+      "total_objects": 406,
+      "total_object_bytes": 1276724716,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 36,
+          "p95_ms": 40
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 12,
+          "p95_ms": 17
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 14,
+          "p95_ms": 17
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 48,
+          "p95_ms": 53
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1170,
+      "write_duration_ms": 2877,
+      "flush_count": 100,
+      "final_rows": 900000,
+      "data_objects": 105,
+      "delete_objects": 105,
+      "total_objects": 105,
+      "total_object_bytes": 33101954,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 14,
+          "p95_ms": 21
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 22,
+          "p95_ms": 26
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1148,
+      "write_duration_ms": 2724,
+      "flush_count": 100,
+      "final_rows": 900000,
+      "data_objects": 105,
+      "delete_objects": 105,
+      "total_objects": 105,
+      "total_object_bytes": 33090678,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 12,
+          "p95_ms": 15
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 20,
+          "p95_ms": 25
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1315,
+      "write_duration_ms": 399228,
+      "flush_count": 400,
+      "final_rows": 1000000,
+      "data_objects": 401,
+      "delete_objects": 1606,
+      "total_objects": 1606,
+      "total_object_bytes": 3997466963,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 56,
+          "p95_ms": 61
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 35,
+          "p95_ms": 37
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 38,
+          "p95_ms": 43
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 32,
+          "p95_ms": 35
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1173,
+      "write_duration_ms": 13989,
+      "flush_count": 400,
+      "final_rows": 1000000,
+      "data_objects": 605,
+      "delete_objects": 605,
+      "total_objects": 605,
+      "total_object_bytes": 117152652,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 24,
+          "p95_ms": 27
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 27,
+          "p95_ms": 27
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 1000
+      },
+      "baseline_load_duration_ms": 1154,
+      "write_duration_ms": 13576,
+      "flush_count": 400,
+      "final_rows": 1000000,
+      "data_objects": 605,
+      "delete_objects": 605,
+      "total_objects": 605,
+      "total_object_bytes": 117168880,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 25,
+          "p95_ms": 47
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 24,
+          "p95_ms": 26
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1383,
+      "write_duration_ms": 242,
+      "flush_count": 10,
+      "final_rows": 1100000,
+      "data_objects": 11,
+      "delete_objects": 0,
+      "total_objects": 46,
+      "total_object_bytes": 14737953,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 38,
+          "p95_ms": 58
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 13,
+          "p95_ms": 15
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 16,
+          "p95_ms": 17
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 19,
+          "p95_ms": 23
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1229,
+      "write_duration_ms": 246,
+      "flush_count": 10,
+      "final_rows": 1100000,
+      "data_objects": 15,
+      "delete_objects": 0,
+      "total_objects": 15,
+      "total_object_bytes": 13929291,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 9
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 6
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 6,
+          "p95_ms": 8
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "append",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 0,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1163,
+      "write_duration_ms": 208,
+      "flush_count": 10,
+      "final_rows": 1100000,
+      "data_objects": 15,
+      "delete_objects": 0,
+      "total_objects": 15,
+      "total_object_bytes": 13927205,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 8,
+          "p95_ms": 10
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 5,
+          "p95_ms": 7
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1319,
+      "write_duration_ms": 26999,
+      "flush_count": 20,
+      "final_rows": 1000000,
+      "data_objects": 21,
+      "delete_objects": 0,
+      "total_objects": 86,
+      "total_object_bytes": 278630188,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 37,
+          "p95_ms": 41
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 11,
+          "p95_ms": 12
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 13,
+          "p95_ms": 15
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 52,
+          "p95_ms": 53
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1170,
+      "write_duration_ms": 891,
+      "flush_count": 20,
+      "final_rows": 1000000,
+      "data_objects": 45,
+      "delete_objects": 20,
+      "total_objects": 45,
+      "total_object_bytes": 18191736,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 15,
+          "p95_ms": 18
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 5
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 22,
+          "p95_ms": 27
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "update-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 100000,
+        "delete_rows": 0,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1154,
+      "write_duration_ms": 834,
+      "flush_count": 20,
+      "final_rows": 1000000,
+      "data_objects": 45,
+      "delete_objects": 20,
+      "total_objects": 45,
+      "total_object_bytes": 18178652,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 13,
+          "p95_ms": 14
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 2
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 16,
+          "p95_ms": 18
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1305,
+      "write_duration_ms": 12836,
+      "flush_count": 10,
+      "final_rows": 900000,
+      "data_objects": 11,
+      "delete_objects": 46,
+      "total_objects": 46,
+      "total_object_bytes": 138637227,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 36,
+          "p95_ms": 40
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 13,
+          "p95_ms": 18
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 14,
+          "p95_ms": 17
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 52,
+          "p95_ms": 54
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1174,
+      "write_duration_ms": 416,
+      "flush_count": 10,
+      "final_rows": 900000,
+      "data_objects": 15,
+      "delete_objects": 15,
+      "total_objects": 15,
+      "total_object_bytes": 14838577,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 14,
+          "p95_ms": 16
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 6
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 21,
+          "p95_ms": 28
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "delete-10pct",
+        "baseline_rows": 1000000,
+        "insert_rows": 0,
+        "update_rows": 0,
+        "delete_rows": 100000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1174,
+      "write_duration_ms": 405,
+      "flush_count": 10,
+      "final_rows": 900000,
+      "data_objects": 15,
+      "delete_objects": 15,
+      "total_objects": 15,
+      "total_object_bytes": 14825219,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 14,
+          "p95_ms": 15
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 21,
+          "p95_ms": 27
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "iceberg-cow",
+        "format": "iceberg",
+        "iceberg_mutation": "cow"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1304,
+      "write_duration_ms": 40040,
+      "flush_count": 40,
+      "final_rows": 1000000,
+      "data_objects": 41,
+      "delete_objects": 166,
+      "total_objects": 166,
+      "total_object_bytes": 405901959,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 37,
+          "p95_ms": 38
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 14,
+          "p95_ms": 17
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 15,
+          "p95_ms": 17
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 18,
+          "p95_ms": 20
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-sqlite",
+        "format": "ducklake",
+        "ducklake_catalog": "sqlite"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1173,
+      "write_duration_ms": 1792,
+      "flush_count": 40,
+      "final_rows": 1000000,
+      "data_objects": 65,
+      "delete_objects": 65,
+      "total_objects": 65,
+      "total_object_bytes": 25748893,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 19,
+          "p95_ms": 21
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 4,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 3,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 30,
+          "p95_ms": 36
+        }
+      ]
+    },
+    {
+      "target": {
+        "name": "ducklake-duckdb",
+        "format": "ducklake",
+        "ducklake_catalog": "duckdb"
+      },
+      "scenario": {
+        "name": "mixed-append-update-delete",
+        "baseline_rows": 1000000,
+        "insert_rows": 100000,
+        "update_rows": 100000,
+        "delete_rows": 100000,
+        "flush_rows": 10000
+      },
+      "baseline_load_duration_ms": 1187,
+      "write_duration_ms": 1697,
+      "flush_count": 40,
+      "final_rows": 1000000,
+      "data_objects": 65,
+      "delete_objects": 65,
+      "total_objects": 65,
+      "total_object_bytes": 25746270,
+      "queries": [
+        {
+          "name": "full_aggregate",
+          "median_ms": 17,
+          "p95_ms": 20
+        },
+        {
+          "name": "selective_range",
+          "median_ms": 3,
+          "p95_ms": 4
+        },
+        {
+          "name": "point_lookup",
+          "median_ms": 2,
+          "p95_ms": 3
+        },
+        {
+          "name": "topn_ordered",
+          "median_ms": 30,
+          "p95_ms": 44
+        }
+      ]
+    }
+  ],
+  "caveats": [
+    "This benchmark bypasses Postgres logical replication and exercises writer + catalog commit + DuckDB reads only.",
+    "Baseline load is performed as one bulk flush and reported separately; write_duration_ms measures only the scenario workload at the configured flush_rows.",
+    "Iceberg and DuckLake write data to local MinIO; DuckLake catalog is local SQLite or DuckDB as configured.",
+    "Read timings include DuckDB query execution over the produced lake but do not include psql-wire server overhead."
+  ]
+}


### PR DESCRIPTION
Closes #70.

Adds benchmark documentation and committed baseline result snapshots for the DuckLake vs Iceberg benchmark harness that was merged in #75.

Included:

- `docs/benchmarks/ducklake-vs-iceberg.md`
  - benchmark purpose
  - run commands
  - workload shape
  - caveats
  - summarized 100k and 1M result tables
  - example read latency table
- `docs/benchmarks/results/*.json`
  - raw JSON result snapshots from the local benchmark run

The benchmark harness itself already exists at:

- `test/integration/lakehouse_feature_benchmark_test.go`

Validation:

```bash
go test -tags integration -run TestLakehouseFeatureBenchmark -count=1 ./test/integration
go test ./internal/ducklake ./internal/iceberg ./config
```
