### PR TITLE
test: add differential query compatibility oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
           -run 'TestEndToEnd$|TestEndToEndUpdateDelete$|TestSchemaEvolution_AddColumn$|TestMutationModesDuckDBCorrectness/cow$'
           ./test/integration
 
+      - name: Query compatibility oracle
+        run: go test -tags integration -v -timeout 10m ./test/querycompat
+
       - name: Stop services
         if: always()
         run: docker compose -f test/integration/docker-compose.yml down -v
@@ -76,6 +79,9 @@ jobs:
 
       - name: Full integration tests
         run: go test -tags integration -short -v -timeout 30m ./test/integration/...
+
+      - name: Query compatibility oracle
+        run: go test -tags integration -v -timeout 10m ./test/querycompat
 
       - name: Stop services
         if: always()

--- a/internal/parquet/builder.go
+++ b/internal/parquet/builder.go
@@ -112,8 +112,10 @@ func oidToParquetNode(oid uint32) parquet.Node {
 		return parquet.Leaf(parquet.DoubleType)
 	case 1082: // date
 		return parquet.Date()
-	case 1114, 1184: // timestamp, timestamptz
-		return parquet.Timestamp(parquet.Microsecond)
+	case 1114: // timestamp without time zone
+		return parquet.TimestampAdjusted(parquet.Microsecond, false)
+	case 1184: // timestamptz
+		return parquet.TimestampAdjusted(parquet.Microsecond, true)
 	case 2950: // uuid
 		return parquet.UUID()
 	case 17: // bytea

--- a/internal/server/catalog_test.go
+++ b/internal/server/catalog_test.go
@@ -11,6 +11,25 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2"
 )
 
+func TestNormalizeDuckDBUUID(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	var value any
+	if err := db.QueryRow(`SELECT UUID '550e8400-e29b-41d4-a716-446655440000'`).Scan(&value); err != nil {
+		t.Fatalf("scan UUID: %v", err)
+	}
+	if _, ok := value.([]byte); !ok {
+		t.Fatalf("UUID scan returned %T, want []byte", value)
+	}
+	if got := normalizeValue(value, "UUID"); got != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Fatalf("normalize UUID = %v, want canonical string", got)
+	}
+}
+
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	duckdb "github.com/duckdb/duckdb-go/v2"
+	"github.com/google/uuid"
 
 	wire "github.com/jeroenrinzema/psql-wire"
 	"github.com/viggy28/streambed/internal/ducklake"
@@ -203,6 +204,11 @@ func (s *Server) Start(ctx context.Context) error {
 	// Create psql-wire server
 	srv, err := wire.NewServer(s.handleParse,
 		wire.Logger(s.logger),
+		// pgx requires this Postgres ParameterStatus before it will use the
+		// simple query protocol. DuckDB also follows standard string escaping.
+		wire.GlobalParameters(wire.Parameters{
+			wire.ParameterStatus("standard_conforming_strings"): "on",
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("create wire server: %w", err)
@@ -280,7 +286,7 @@ func (s *Server) handleParse(ctx context.Context, query string) (wire.PreparedSt
 		}
 		// Normalize DuckDB-specific value types that psql-wire can't encode directly.
 		for i, v := range vals {
-			vals[i] = normalizeValue(v)
+			vals[i] = normalizeValue(v, colTypes[i].DatabaseTypeName())
 		}
 		resultRows = append(resultRows, vals)
 	}
@@ -443,7 +449,7 @@ func duckDBTypeToOID(typeName string) uint32 {
 // normalizeValue converts DuckDB-specific value types into plain Go types
 // that psql-wire's text encoder can handle. Anything it doesn't recognize
 // is returned unchanged.
-func normalizeValue(v any) any {
+func normalizeValue(v any, databaseType string) any {
 	switch x := v.(type) {
 	case duckdb.Decimal:
 		return x.String()
@@ -452,6 +458,20 @@ func normalizeValue(v any) any {
 			return nil
 		}
 		return x.String()
+	case []byte:
+		if strings.EqualFold(databaseType, "UUID") && len(x) == 16 {
+			if id, err := uuid.FromBytes(x); err == nil {
+				return id.String()
+			}
+		}
+		return x
+	case duckdb.UUID:
+		return uuid.UUID(x).String()
+	case *duckdb.UUID:
+		if x == nil {
+			return nil
+		}
+		return uuid.UUID(*x).String()
 	default:
 		return v
 	}

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -5,6 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$PROJECT_DIR/test/integration/docker-compose.yml"
 
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down -v
+}
+trap cleanup EXIT
+
 echo "==> Starting Postgres and MinIO..."
 docker compose -f "$COMPOSE_FILE" up -d --wait
 
@@ -14,9 +19,6 @@ sleep 3
 echo "==> Running integration tests..."
 cd "$PROJECT_DIR"
 go test -tags integration -v -timeout 120s ./test/integration/...
-TEST_EXIT=$?
 
-echo "==> Stopping services..."
-docker compose -f "$COMPOSE_FILE" down -v
-
-exit $TEST_EXIT
+echo "==> Running query compatibility oracle..."
+go test -tags integration -v -timeout 10m ./test/querycompat

--- a/test/querycompat/cases_test.go
+++ b/test/querycompat/cases_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+package querycompat
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type expectation string
+
+const (
+	supported       expectation = "supported"
+	unsupported     expectation = "unsupported"
+	knownDifference expectation = "known_difference"
+)
+
+type expectedBehavior struct {
+	Expectation expectation
+	ErrorMatch  string
+	IgnoreOIDs  []int
+	Reason      string
+}
+
+type queryCase struct {
+	Name         string
+	Category     string
+	Query        string
+	Ordered      bool
+	FloatEpsilon float64
+	Default      expectedBehavior
+	ByTarget     map[targetFormat]expectedBehavior
+}
+
+func (tc queryCase) behavior(target targetFormat) expectedBehavior {
+	if behavior, ok := tc.ByTarget[target]; ok {
+		return behavior
+	}
+	return tc.Default
+}
+
+func supportedCase(name, category, query string) queryCase {
+	return queryCase{
+		Name:     name,
+		Category: category,
+		Query:    query,
+		Ordered:  true,
+		Default:  expectedBehavior{Expectation: supported},
+	}
+}
+
+var queryCases = []queryCase{
+	supportedCase("integer projection", "selection", `SELECT id, int4_value FROM oracle_values ORDER BY id`),
+	supportedCase("boolean filter", "selection", `SELECT id FROM oracle_values WHERE bool_value IS TRUE ORDER BY id`),
+	supportedCase("limit and offset", "selection", `SELECT id FROM oracle_values ORDER BY id LIMIT 2 OFFSET 1`),
+	supportedCase("distinct with null", "selection", `SELECT DISTINCT group_id FROM oracle_values ORDER BY group_id NULLS LAST`),
+	supportedCase("coalesce", "nulls", `SELECT id, coalesce(text_value, 'missing') AS value FROM oracle_values ORDER BY id`),
+	supportedCase("nullif", "nulls", `SELECT id, nullif(int4_value, 0) AS value FROM oracle_values ORDER BY id`),
+	supportedCase("case expression", "expressions", `SELECT id, CASE WHEN bool_value THEN 'yes' WHEN bool_value IS FALSE THEN 'no' ELSE 'unknown' END AS value FROM oracle_values ORDER BY id`),
+	supportedCase("integer arithmetic", "expressions", `SELECT id, int4_value + 1 AS value FROM oracle_values WHERE int4_value IS NOT NULL ORDER BY id`),
+	supportedCase("integer comparison", "expressions", `SELECT id, int8_value > 0 AS positive FROM oracle_values WHERE int8_value IS NOT NULL ORDER BY id`),
+	supportedCase("lower", "strings", `SELECT id, lower(text_value) AS value FROM oracle_values ORDER BY id`),
+	supportedCase("concatenation", "strings", `SELECT id, text_value || ':' || id::text AS value FROM oracle_values ORDER BY id`),
+	supportedCase("substring", "strings", `SELECT id, substring(text_value FROM 1 FOR 3) AS value FROM oracle_values ORDER BY id`),
+	supportedCase("ilike", "strings", `SELECT id FROM oracle_values WHERE text_value ILIKE '%HELLO%' ORDER BY id`),
+	supportedCase("date projection", "datetime", `SELECT id, date_value FROM oracle_values ORDER BY id`),
+	supportedCase("date arithmetic", "datetime", `SELECT id, date_value + 1 AS value FROM oracle_values ORDER BY id`),
+	supportedCase("timestamp projection", "datetime", `SELECT id, timestamp_value FROM oracle_values ORDER BY id`),
+	supportedCase("timestamptz projection", "datetime", `SELECT id, timestamptz_value FROM oracle_values ORDER BY id`),
+	supportedCase("count", "aggregates", `SELECT count(*) AS value FROM oracle_values`),
+	supportedCase("minimum integer", "aggregates", `SELECT min(int4_value) AS value FROM oracle_values`),
+	supportedCase("maximum bigint", "aggregates", `SELECT max(int8_value) AS value FROM oracle_values`),
+	supportedCase("grouped count", "aggregates", `SELECT group_id, count(*) AS value FROM oracle_values GROUP BY group_id ORDER BY group_id NULLS LAST`),
+	supportedCase("inner join", "joins", `SELECT v.id, g.name FROM oracle_values v JOIN oracle_groups g ON g.id = v.group_id ORDER BY v.id`),
+	supportedCase("left join", "joins", `SELECT g.id, count(v.id) AS value FROM oracle_groups g LEFT JOIN oracle_values v ON v.group_id = g.id GROUP BY g.id ORDER BY g.id`),
+	supportedCase("common table expression", "advanced", `WITH selected AS (SELECT id, group_id FROM oracle_values WHERE id <= 3) SELECT id, group_id FROM selected ORDER BY id`),
+	supportedCase("exists subquery", "advanced", `SELECT g.id, EXISTS (SELECT 1 FROM oracle_values v WHERE v.group_id = g.id) AS has_values FROM oracle_groups g ORDER BY g.id`),
+	supportedCase("row number window", "advanced", `SELECT id, row_number() OVER (PARTITION BY group_id ORDER BY id) AS value FROM oracle_values ORDER BY id`),
+	supportedCase("union all", "advanced", `SELECT id FROM oracle_groups UNION ALL SELECT id FROM oracle_values WHERE id > 3 ORDER BY id`),
+	supportedCase("boolean projection", "types", `SELECT id, bool_value FROM oracle_values ORDER BY id`),
+	supportedCase("uuid projection", "types", `SELECT id, uuid_value FROM oracle_values ORDER BY id`),
+	supportedCase("bytea projection", "types", `SELECT id, bytea_value FROM oracle_values ORDER BY id`),
+	supportedCase("real projection", "types", `SELECT id, real_value FROM oracle_values ORDER BY id`),
+	supportedCase("double projection", "types", `SELECT id, double_value FROM oracle_values ORDER BY id`),
+	{
+		Name: "smallint storage mapping", Category: "types",
+		Query: `SELECT id, int2_value FROM oracle_values ORDER BY id`, Ordered: true,
+		Default: expectedBehavior{
+			Expectation: knownDifference,
+			IgnoreOIDs:  []int{1},
+			Reason:      "Iceberg maps Postgres SMALLINT to Iceberg int, which DuckDB exposes as INTEGER",
+		},
+		ByTarget: map[targetFormat]expectedBehavior{
+			targetDuckLake: {Expectation: supported},
+		},
+	},
+	{
+		Name: "numeric storage mapping", Category: "types",
+		Query: `SELECT id, numeric_value FROM oracle_values ORDER BY id`, Ordered: true,
+		Default: expectedBehavior{
+			Expectation: knownDifference,
+			IgnoreOIDs:  []int{1},
+			Reason:      "numeric values are currently stored and exposed as strings",
+		},
+	},
+	{
+		Name: "unconstrained numeric storage mapping", Category: "types",
+		Query: `SELECT id, unconstrained_value FROM oracle_values ORDER BY id`, Ordered: true,
+		Default: expectedBehavior{
+			Expectation: knownDifference,
+			IgnoreOIDs:  []int{1},
+			Reason:      "unconstrained numeric values are currently stored and exposed as strings",
+		},
+	},
+	{
+		Name: "varchar storage mapping", Category: "types",
+		Query: `SELECT id, varchar_value FROM oracle_values ORDER BY id`, Ordered: true,
+		Default: expectedBehavior{
+			Expectation: knownDifference,
+			IgnoreOIDs:  []int{1},
+			Reason:      "DuckDB VARCHAR is exposed as Postgres TEXT rather than VARCHAR",
+		},
+	},
+	{
+		Name: "jsonb storage mapping", Category: "types",
+		Query: `SELECT id, jsonb_value FROM oracle_values ORDER BY id`, Ordered: true,
+		Default: expectedBehavior{
+			Expectation: knownDifference,
+			IgnoreOIDs:  []int{1},
+			Reason:      "JSONB is currently stored and exposed as text",
+		},
+	},
+	{
+		Name: "postgres session function", Category: "unsupported",
+		Query: `SELECT pg_backend_pid() AS value`, Ordered: true,
+		Default: expectedBehavior{
+			Expectation: unsupported,
+			ErrorMatch:  `(?i)(pg_backend_pid|does not exist|not found)`,
+			Reason:      "DuckDB does not implement Postgres backend session functions",
+		},
+	},
+}
+
+func validateCases() error {
+	seen := make(map[string]struct{}, len(queryCases))
+	for _, tc := range queryCases {
+		if tc.Name == "" || tc.Category == "" || tc.Query == "" {
+			return fmt.Errorf("query case has empty name, category, or query: %+v", tc)
+		}
+		if _, exists := seen[tc.Name]; exists {
+			return fmt.Errorf("duplicate query case name %q", tc.Name)
+		}
+		seen[tc.Name] = struct{}{}
+		for _, target := range []targetFormat{targetIceberg, targetDuckLake} {
+			behavior := tc.behavior(target)
+			switch behavior.Expectation {
+			case supported:
+				if behavior.ErrorMatch != "" || len(behavior.IgnoreOIDs) > 0 {
+					return fmt.Errorf("supported case %q has error/OID exceptions for %s", tc.Name, target)
+				}
+			case unsupported:
+				if behavior.ErrorMatch == "" || behavior.Reason == "" {
+					return fmt.Errorf("unsupported case %q needs error match and reason for %s", tc.Name, target)
+				}
+				if _, err := regexp.Compile(behavior.ErrorMatch); err != nil {
+					return fmt.Errorf("unsupported case %q has invalid error regex: %w", tc.Name, err)
+				}
+			case knownDifference:
+				if behavior.Reason == "" || len(behavior.IgnoreOIDs) == 0 {
+					return fmt.Errorf("known difference %q needs reason and explicit OID exceptions for %s", tc.Name, target)
+				}
+			default:
+				return fmt.Errorf("case %q has invalid expectation %q for %s", tc.Name, behavior.Expectation, target)
+			}
+		}
+	}
+	return nil
+}

--- a/test/querycompat/compare_test.go
+++ b/test/querycompat/compare_test.go
@@ -1,0 +1,324 @@
+//go:build integration
+
+package querycompat
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestEqualFloatSpecialValues(t *testing.T) {
+	if err := equalValue(701, []byte("NaN"), []byte("1"), 0); err == nil {
+		t.Fatal("one-sided NaN must not compare equal")
+	}
+	if err := equalValue(701, []byte("Infinity"), []byte("-Infinity"), 0); err == nil {
+		t.Fatal("opposite infinities must not compare equal")
+	}
+	if err := equalValue(701, []byte("NaN"), []byte("NaN"), 0); err != nil {
+		t.Fatalf("matching NaN values should compare equal: %v", err)
+	}
+}
+
+type resultColumn struct {
+	Name string
+	OID  uint32
+}
+
+type queryResult struct {
+	Columns []resultColumn
+	Rows    [][][]byte
+}
+
+func runQueryCase(t *testing.T, ctx context.Context, source, streambed *pgx.Conn, target targetFormat, tc queryCase) {
+	t.Helper()
+	behavior := tc.behavior(target)
+
+	sourceResult, err := executeQuery(ctx, source, tc.Query)
+	if err != nil {
+		t.Fatalf("source Postgres rejected oracle query:\n%s\nerror: %v", tc.Query, err)
+	}
+	streambedResult, streambedErr := executeQuery(ctx, streambed, tc.Query)
+
+	switch behavior.Expectation {
+	case unsupported:
+		if streambedErr == nil {
+			t.Fatalf("query unexpectedly became supported; update its classification\nquery: %s", tc.Query)
+		}
+		if !regexp.MustCompile(behavior.ErrorMatch).MatchString(streambedErr.Error()) {
+			t.Fatalf("Streambed error did not match %q\nquery: %s\nerror: %v", behavior.ErrorMatch, tc.Query, streambedErr)
+		}
+		return
+	case supported, knownDifference:
+		if streambedErr != nil {
+			t.Fatalf("Streambed query failed\ntarget: %s\nquery: %s\nerror: %v", target, tc.Query, streambedErr)
+		}
+	default:
+		t.Fatalf("invalid expectation %q", behavior.Expectation)
+	}
+
+	ignored := make(map[int]bool, len(behavior.IgnoreOIDs))
+	for _, index := range behavior.IgnoreOIDs {
+		ignored[index] = true
+	}
+	metadataDifference := compareColumns(t, tc.Query, sourceResult.Columns, streambedResult.Columns, ignored)
+	if behavior.Expectation == knownDifference && !metadataDifference {
+		t.Fatalf("known difference no longer differs; reclassify the case\ntarget: %s\nreason: %s\nquery: %s", target, behavior.Reason, tc.Query)
+	}
+	compareRows(t, tc, sourceResult, streambedResult)
+}
+
+func executeQuery(ctx context.Context, conn *pgx.Conn, query string) (queryResult, error) {
+	rows, err := conn.Query(ctx, query, pgx.QueryExecModeSimpleProtocol)
+	if err != nil {
+		return queryResult{}, err
+	}
+	defer rows.Close()
+
+	fields := rows.FieldDescriptions()
+	result := queryResult{Columns: make([]resultColumn, len(fields))}
+	for i, field := range fields {
+		result.Columns[i] = resultColumn{Name: field.Name, OID: field.DataTypeOID}
+	}
+	for rows.Next() {
+		raw := rows.RawValues()
+		row := make([][]byte, len(raw))
+		for i := range raw {
+			if raw[i] != nil {
+				row[i] = bytes.Clone(raw[i])
+			}
+		}
+		result.Rows = append(result.Rows, row)
+	}
+	if err := rows.Err(); err != nil {
+		return queryResult{}, err
+	}
+	return result, nil
+}
+
+func compareColumns(t *testing.T, query string, source, streambed []resultColumn, ignored map[int]bool) bool {
+	t.Helper()
+	if len(source) != len(streambed) {
+		t.Fatalf("column count mismatch\nquery: %s\nPostgres: %v\nStreambed: %v", query, source, streambed)
+	}
+	difference := false
+	for i := range source {
+		if source[i].Name != streambed[i].Name {
+			t.Fatalf("column name mismatch at index %d\nquery: %s\nPostgres: %q\nStreambed: %q", i, query, source[i].Name, streambed[i].Name)
+		}
+		if source[i].OID != streambed[i].OID {
+			if ignored[i] {
+				difference = true
+				continue
+			}
+			t.Fatalf("column OID mismatch for %q at index %d\nquery: %s\nPostgres: %d\nStreambed: %d", source[i].Name, i, query, source[i].OID, streambed[i].OID)
+		}
+	}
+	for index := range ignored {
+		if index < 0 || index >= len(source) {
+			t.Fatalf("ignored OID index %d is outside %d result columns for query %s", index, len(source), query)
+		}
+	}
+	return difference
+}
+
+func compareRows(t *testing.T, tc queryCase, source, streambed queryResult) {
+	t.Helper()
+	if len(source.Rows) != len(streambed.Rows) {
+		t.Fatalf("row count mismatch\nquery: %s\nPostgres: %d\nStreambed: %d", tc.Query, len(source.Rows), len(streambed.Rows))
+	}
+
+	sourceRows := source.Rows
+	streambedRows := streambed.Rows
+	if !tc.Ordered {
+		sourceRows = sortedRows(t, source.Columns, sourceRows)
+		streambedRows = sortedRows(t, source.Columns, streambedRows)
+	}
+	for rowIndex := range sourceRows {
+		if len(sourceRows[rowIndex]) != len(streambedRows[rowIndex]) {
+			t.Fatalf("row width mismatch at row %d\nquery: %s", rowIndex, tc.Query)
+		}
+		for columnIndex := range sourceRows[rowIndex] {
+			if err := equalValue(source.Columns[columnIndex].OID, sourceRows[rowIndex][columnIndex], streambedRows[rowIndex][columnIndex], tc.FloatEpsilon); err != nil {
+				t.Fatalf("value mismatch at row %d, column %d (%s, OID %d)\nquery: %s\nPostgres: %q\nStreambed: %q\nreason: %v",
+					rowIndex, columnIndex, source.Columns[columnIndex].Name, source.Columns[columnIndex].OID,
+					tc.Query, sourceRows[rowIndex][columnIndex], streambedRows[rowIndex][columnIndex], err)
+			}
+		}
+	}
+}
+
+func sortedRows(t *testing.T, columns []resultColumn, rows [][][]byte) [][][]byte {
+	t.Helper()
+	result := append([][][]byte(nil), rows...)
+	sort.Slice(result, func(i, j int) bool {
+		return canonicalRow(columns, result[i]) < canonicalRow(columns, result[j])
+	})
+	return result
+}
+
+func canonicalRow(columns []resultColumn, row [][]byte) string {
+	parts := make([]string, len(row))
+	for i, value := range row {
+		canonical, err := canonicalValue(columns[i].OID, value)
+		if err != nil {
+			canonical = string(value)
+		}
+		parts[i] = canonical
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func equalValue(oid uint32, source, streambed []byte, epsilon float64) error {
+	if source == nil || streambed == nil {
+		if source == nil && streambed == nil {
+			return nil
+		}
+		return fmt.Errorf("NULL mismatch")
+	}
+	if oid == 700 || oid == 701 {
+		a, err := strconv.ParseFloat(string(source), 64)
+		if err != nil {
+			return fmt.Errorf("parse Postgres float: %w", err)
+		}
+		b, err := strconv.ParseFloat(string(streambed), 64)
+		if err != nil {
+			return fmt.Errorf("parse Streambed float: %w", err)
+		}
+		if math.IsNaN(a) || math.IsNaN(b) {
+			if math.IsNaN(a) && math.IsNaN(b) {
+				return nil
+			}
+			return fmt.Errorf("NaN mismatch: %g != %g", a, b)
+		}
+		if math.IsInf(a, 0) || math.IsInf(b, 0) {
+			if a == b {
+				return nil
+			}
+			return fmt.Errorf("infinity mismatch: %g != %g", a, b)
+		}
+		if epsilon == 0 {
+			if oid == 700 {
+				epsilon = 1e-6
+			} else {
+				epsilon = 1e-12
+			}
+		}
+		if math.Abs(a-b) > epsilon {
+			return fmt.Errorf("float difference %g exceeds epsilon %g", math.Abs(a-b), epsilon)
+		}
+		return nil
+	}
+	a, err := canonicalValue(oid, source)
+	if err != nil {
+		return fmt.Errorf("normalize Postgres value: %w", err)
+	}
+	b, err := canonicalValue(oid, streambed)
+	if err != nil {
+		return fmt.Errorf("normalize Streambed value: %w", err)
+	}
+	if a != b {
+		return fmt.Errorf("normalized values differ: %q != %q", a, b)
+	}
+	return nil
+}
+
+func canonicalValue(oid uint32, value []byte) (string, error) {
+	if value == nil {
+		return "<NULL>", nil
+	}
+	s := string(value)
+	switch oid {
+	case 16:
+		switch strings.ToLower(s) {
+		case "t", "true":
+			return "true", nil
+		case "f", "false":
+			return "false", nil
+		default:
+			return "", fmt.Errorf("invalid boolean %q", s)
+		}
+	case 20, 21, 23:
+		n := new(big.Int)
+		if _, ok := n.SetString(s, 10); !ok {
+			return "", fmt.Errorf("invalid integer %q", s)
+		}
+		return n.String(), nil
+	case 1700:
+		n := new(big.Rat)
+		if _, ok := n.SetString(s); !ok {
+			return "", fmt.Errorf("invalid numeric %q", s)
+		}
+		return n.RatString(), nil
+	case 1082:
+		parsed, err := scanTime(oid, value)
+		if err != nil {
+			return "", err
+		}
+		return parsed.Format("2006-01-02"), nil
+	case 1114:
+		parsed, err := scanTime(oid, value)
+		if err != nil {
+			return "", err
+		}
+		return parsed.Format("2006-01-02T15:04:05.999999999"), nil
+	case 1184:
+		parsed, err := scanTime(oid, value)
+		if err != nil {
+			return "", err
+		}
+		return parsed.UTC().Format(time.RFC3339Nano), nil
+	case 2950:
+		return strings.ToLower(s), nil
+	case 17:
+		decoded, err := decodeBytea(s)
+		if err != nil {
+			return "", err
+		}
+		return hex.EncodeToString(decoded), nil
+	case 114, 3802:
+		var decoded any
+		if err := json.Unmarshal(value, &decoded); err != nil {
+			return "", fmt.Errorf("invalid JSON: %w", err)
+		}
+		canonical, err := json.Marshal(decoded)
+		if err != nil {
+			return "", err
+		}
+		return string(canonical), nil
+	default:
+		return s, nil
+	}
+}
+
+func scanTime(oid uint32, value []byte) (time.Time, error) {
+	var result time.Time
+	if err := pgtype.NewMap().Scan(oid, pgtype.TextFormatCode, value, &result); err != nil {
+		return time.Time{}, fmt.Errorf("invalid time %q for OID %d: %w", value, oid, err)
+	}
+	return result, nil
+}
+
+func decodeBytea(value string) ([]byte, error) {
+	if strings.HasPrefix(value, `\x`) {
+		return hex.DecodeString(value[2:])
+	}
+	var result []byte
+	if err := pgtype.NewMap().Scan(17, pgtype.TextFormatCode, []byte(value), &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/test/querycompat/fixture_test.go
+++ b/test/querycompat/fixture_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package querycompat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const fixtureValueCount = 5
+
+func cleanupSource(t *testing.T, conn *pgx.Conn, slot string) {
+	t.Helper()
+	ctx := context.Background()
+	if slot != "" {
+		_, _ = conn.Exec(ctx, `SELECT pg_drop_replication_slot(slot_name)
+			FROM pg_replication_slots WHERE slot_name = $1 AND active = false`, slot)
+		_, _ = conn.Exec(ctx, "DROP PUBLICATION IF EXISTS "+pgx.Identifier{slot}.Sanitize())
+	}
+	_, _ = conn.Exec(ctx, "DROP TABLE IF EXISTS oracle_values")
+	_, _ = conn.Exec(ctx, "DROP TABLE IF EXISTS oracle_groups")
+}
+
+func createFixtureSchema(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	ctx := context.Background()
+	statements := []string{
+		`CREATE TABLE oracle_groups (
+			id   INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			tier INTEGER
+		)`,
+		`CREATE TABLE oracle_values (
+			id                  INTEGER PRIMARY KEY,
+			group_id            INTEGER,
+			bool_value          BOOLEAN,
+			int2_value          SMALLINT,
+			int4_value          INTEGER,
+			int8_value          BIGINT,
+			numeric_value       NUMERIC(18,4),
+			unconstrained_value NUMERIC,
+			real_value          REAL,
+			double_value        DOUBLE PRECISION,
+			text_value          TEXT,
+			varchar_value       VARCHAR(32),
+			date_value          DATE,
+			timestamp_value     TIMESTAMP,
+			timestamptz_value   TIMESTAMPTZ,
+			uuid_value          UUID,
+			bytea_value         BYTEA,
+			jsonb_value         JSONB
+		)`,
+	}
+	for _, statement := range statements {
+		if _, err := conn.Exec(ctx, statement); err != nil {
+			t.Fatalf("create query compatibility fixture: %v\n%s", err, statement)
+		}
+	}
+}
+
+func insertFixture(t *testing.T, conn *pgx.Conn) string {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin fixture insert: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	statements := []string{
+		`INSERT INTO oracle_groups (id, name, tier) VALUES
+			(1, 'alpha', 1),
+			(2, 'βeta', 1),
+			(3, 'empty', NULL)`,
+		`INSERT INTO oracle_values VALUES
+			(1, 1, true,  -12, 123456,  9007199254740991,
+			 12.5000, 12345678901234567890.12345, 1.25,  0.125,
+			 'hello', 'apple', DATE '2024-02-29',
+			 TIMESTAMP '2024-01-02 03:04:05.123456',
+			 TIMESTAMPTZ '2024-01-02 03:04:05.123456+00',
+			 '550e8400-e29b-41d4-a716-446655440000', decode('00DEADFF', 'hex'),
+			 '{"a":1,"tags":["x","y"]}'),
+			(2, 1, false, 0, -1, -9007199254740991,
+			 -0.0100, -0.00000000000000000001, -1.25, -0.125,
+			 '', '', DATE '1970-01-01', TIMESTAMP '1970-01-01 00:00:00',
+			 TIMESTAMPTZ '2024-01-01 23:00:00-05',
+			 '00000000-0000-0000-0000-000000000000', decode('', 'hex'),
+			 '{"a":null}'),
+			(3, 2, NULL, NULL, NULL, NULL,
+			 NULL, NULL, NULL, NULL,
+			 'Unicode: café 🚀', NULL, NULL, NULL, NULL,
+			 NULL, NULL, NULL),
+			(4, NULL, true, 12, 123456, 42,
+			 12.5000, 100, 1.25, 0.125,
+			 'hello', 'banana', DATE '2024-02-29',
+			 TIMESTAMP '2024-01-02 03:04:05.123456',
+			 TIMESTAMPTZ '2024-01-02 03:04:05.123456+00',
+			 '550e8400-e29b-41d4-a716-446655440001', decode('00DEADFF', 'hex'),
+			 '{"tags":["y","x"],"a":1}'),
+			(5, 2, false, 7, 0, 0,
+			 0.0000, 0, 0, 0,
+			 'zebra', 'zebra', DATE '2000-01-01',
+			 TIMESTAMP '2000-01-01 12:30:00',
+			 TIMESTAMPTZ '2000-01-01 12:30:00+00',
+			 '550e8400-e29b-41d4-a716-446655440002', decode('FF', 'hex'),
+			 '[]')`,
+	}
+	for _, statement := range statements {
+		if _, err := tx.Exec(ctx, statement); err != nil {
+			t.Fatalf("insert query compatibility fixture: %v\n%s", err, statement)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit fixture insert: %v", err)
+	}
+
+	var commitLSN string
+	if err := conn.QueryRow(ctx, "SELECT pg_current_wal_lsn()::text").Scan(&commitLSN); err != nil {
+		t.Fatalf("read fixture commit LSN: %v", err)
+	}
+	return commitLSN
+}

--- a/test/querycompat/harness_test.go
+++ b/test/querycompat/harness_test.go
@@ -1,0 +1,333 @@
+//go:build integration
+
+package querycompat
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	sourceURL     = "postgres://postgres:test@localhost:5434/postgres"
+	minioEndpoint = "http://localhost:9002"
+	s3Bucket      = "streambed"
+	s3Region      = "us-east-1"
+)
+
+type targetFormat string
+
+const (
+	targetIceberg  targetFormat = "iceberg"
+	targetDuckLake targetFormat = "ducklake"
+)
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+type runningProcess struct {
+	cmd     *exec.Cmd
+	output  *lockedBuffer
+	done    chan struct{}
+	waitErr error
+}
+
+func startProcess(t *testing.T, binary string, args ...string) *runningProcess {
+	t.Helper()
+	output := &lockedBuffer{}
+	cmd := exec.Command(binary, args...)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s %v: %v", binary, args, err)
+	}
+	p := &runningProcess{cmd: cmd, output: output, done: make(chan struct{})}
+	go func() {
+		p.waitErr = cmd.Wait()
+		close(p.done)
+	}()
+	return p
+}
+
+func (p *runningProcess) stop(t *testing.T) {
+	t.Helper()
+	if p == nil || p.cmd.Process == nil {
+		return
+	}
+	if err := p.cmd.Process.Signal(os.Interrupt); err != nil && !strings.Contains(err.Error(), "process already finished") {
+		t.Logf("signal process: %v", err)
+	}
+	select {
+	case <-p.done:
+		if p.waitErr != nil {
+			t.Fatalf("streambed exited after interrupt: %v\n%s", p.waitErr, p.output.String())
+		}
+	case <-time.After(30 * time.Second):
+		_ = p.cmd.Process.Kill()
+		<-p.done
+		t.Fatalf("streambed did not stop within 30s\n%s", p.output.String())
+	}
+}
+
+func (p *runningProcess) kill() {
+	if p == nil || p.cmd.Process == nil {
+		return
+	}
+	select {
+	case <-p.done:
+		return
+	default:
+	}
+	_ = p.cmd.Process.Kill()
+	select {
+	case <-p.done:
+	case <-time.After(5 * time.Second):
+	}
+}
+
+func TestQueryCompatibility(t *testing.T) {
+	if err := validateCases(); err != nil {
+		t.Fatalf("invalid query compatibility cases: %v", err)
+	}
+	ensureDependencies(t)
+	root := repositoryRoot(t)
+	binary := filepath.Join(t.TempDir(), "streambed")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/streambed")
+	build.Dir = root
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build streambed: %v\n%s", err, output)
+	}
+
+	for _, target := range []targetFormat{targetIceberg, targetDuckLake} {
+		t.Run(string(target), func(t *testing.T) {
+			runTargetCompatibility(t, binary, target)
+		})
+	}
+}
+
+func runTargetCompatibility(t *testing.T, binary string, target targetFormat) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	source, err := pgx.Connect(ctx, sourceURL)
+	if err != nil {
+		t.Fatalf("connect source Postgres: %v", err)
+	}
+	defer source.Close(context.Background())
+
+	suffix := fmt.Sprintf("%s_%d", target, time.Now().UnixNano())
+	slot := "querycompat_" + suffix
+	prefix := "querycompat/" + suffix
+	tempDir := t.TempDir()
+	statePath := filepath.Join(tempDir, "state.db")
+	catalogPath := filepath.Join(tempDir, "ducklake.sqlite")
+	dataPath := fmt.Sprintf("s3://%s/%s/ducklake/", s3Bucket, prefix)
+
+	cleanupSource(t, source, slot)
+	createFixtureSchema(t, source)
+	defer cleanupSource(t, source, slot)
+
+	syncArgs := []string{
+		"sync",
+		"--source-url=" + sourceURL,
+		"--s3-bucket=" + s3Bucket,
+		"--s3-prefix=" + prefix,
+		"--s3-endpoint=" + minioEndpoint,
+		"--s3-region=" + s3Region,
+		"--target-format=" + string(target),
+		"--slot-name=" + slot,
+		"--state-path=" + statePath,
+		"--flush-rows=1000",
+		"--flush-interval=1s",
+		"--include-tables=public.oracle_groups,public.oracle_values",
+		"--log-level=INFO",
+	}
+	if target == targetDuckLake {
+		syncArgs = append(syncArgs,
+			"--ducklake-catalog="+catalogPath,
+			"--ducklake-data-path="+dataPath,
+		)
+	}
+
+	syncProcess := startProcess(t, binary, syncArgs...)
+	t.Cleanup(syncProcess.kill)
+	waitForReplicationReady(t, ctx, source, slot, syncProcess)
+	fixtureLSN := insertFixture(t, source)
+	waitForSync(t, ctx, source, slot, fixtureLSN, syncProcess)
+	syncProcess.stop(t) // graceful shutdown performs the final durable flush
+
+	port := freePort(t)
+	queryAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	queryArgs := []string{
+		"query",
+		"--listen-addr=" + queryAddr,
+		"--s3-bucket=" + s3Bucket,
+		"--s3-prefix=" + prefix,
+		"--s3-endpoint=" + minioEndpoint,
+		"--s3-region=" + s3Region,
+		"--target-format=" + string(target),
+		"--log-level=INFO",
+	}
+	if target == targetDuckLake {
+		queryArgs = append(queryArgs,
+			"--ducklake-catalog="+catalogPath,
+			"--ducklake-data-path="+dataPath,
+		)
+	}
+	queryProcess := startProcess(t, binary, queryArgs...)
+	t.Cleanup(queryProcess.kill)
+
+	streambedURL := fmt.Sprintf("postgres://querycompat@%s/postgres?sslmode=disable", queryAddr)
+	streambed := waitForQueryReady(t, ctx, streambedURL, queryProcess)
+	defer streambed.Close(context.Background())
+
+	for _, tc := range queryCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runQueryCase(t, ctx, source, streambed, target, tc)
+		})
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func ensureDependencies(t *testing.T) {
+	t.Helper()
+	for name, address := range map[string]string{
+		"Postgres": "localhost:5434",
+		"MinIO":    "localhost:9002",
+	} {
+		conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+		if err != nil {
+			t.Skipf("%s is not available at %s: %v", name, address, err)
+		}
+		_ = conn.Close()
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocate query port: %v", err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForReplicationReady(t *testing.T, ctx context.Context, source *pgx.Conn, slot string, process *runningProcess) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-process.done:
+			t.Fatalf("streambed sync exited before replication was ready: %v\n%s", process.waitErr, process.output.String())
+		default:
+		}
+		var ready bool
+		err := source.QueryRow(ctx, `SELECT EXISTS (
+			SELECT 1 FROM pg_replication_slots WHERE slot_name = $1
+		) AND EXISTS (
+			SELECT 1 FROM pg_publication WHERE pubname = $1
+		)`, slot).Scan(&ready)
+		if err == nil && ready {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("wait for replication setup: %v", ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	t.Fatalf("replication slot/publication %s was not ready within 20s\n%s", slot, process.output.String())
+}
+
+func waitForSync(t *testing.T, ctx context.Context, source *pgx.Conn, slot, fixtureLSN string, process *runningProcess) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	var confirmedLSN string
+	for time.Now().Before(deadline) {
+		select {
+		case <-process.done:
+			t.Fatalf("streambed sync exited before fixture LSN %s was durable: %v\n%s", fixtureLSN, process.waitErr, process.output.String())
+		default:
+		}
+
+		var reached bool
+		err := source.QueryRow(ctx, `SELECT confirmed_flush_lsn::text, confirmed_flush_lsn >= $2::pg_lsn
+			FROM pg_replication_slots WHERE slot_name = $1`, slot, fixtureLSN).Scan(&confirmedLSN, &reached)
+		if err == nil && reached {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("wait for fixture LSN %s: %v", fixtureLSN, ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	t.Fatalf("streambed did not make fixture LSN %s durable within 30s (confirmed=%s)\n%s",
+		fixtureLSN, confirmedLSN, process.output.String())
+}
+
+func waitForQueryReady(t *testing.T, ctx context.Context, url string, process *runningProcess) *pgx.Conn {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		select {
+		case <-process.done:
+			t.Fatalf("streambed query server exited before readiness: %v\n%s", process.waitErr, process.output.String())
+		default:
+		}
+		conn, err := pgx.Connect(ctx, url)
+		if err == nil {
+			var count int
+			err = conn.QueryRow(ctx, "SELECT count(*) FROM oracle_values").Scan(&count)
+			if err == nil && count == fixtureValueCount {
+				return conn
+			}
+			_ = conn.Close(context.Background())
+			if err == nil {
+				err = fmt.Errorf("oracle_values count=%d, want %d", count, fixtureValueCount)
+			}
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			t.Fatalf("wait for query server: %v\n%s", ctx.Err(), process.output.String())
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	t.Fatalf("query server was not ready within 30s: %v\n%s", lastErr, process.output.String())
+	return nil
+}


### PR DESCRIPTION
## Summary

Add a purpose-built differential query compatibility harness that treats source Postgres as the oracle and compares it with Streambed through the actual Postgres-wire endpoint.

The suite runs the same deterministic fixture and query matrix against both Iceberg and DuckLake targets. It compares query behavior, column names, Postgres OIDs, nulls, row multiplicity, ordering, and type-aware values.

Closes #78.

## Implementation

- Add `test/querycompat` with a deterministic Postgres fixture and declarative query cases.
- Build and start the real Streambed binary for sync and standalone query serving.
- Wait for the fixture commit LSN instead of using fixed sleeps.
- Connect to source Postgres and Streambed with pgx simple protocol.
- Compare integers/text exactly, decimals with exact rational arithmetic, floats with OID-specific tolerances, timestamps by their SQL semantics, timestamptz in UTC, JSON structurally, and UUID/bytea canonically.
- Run the same cases for Iceberg and DuckLake with explicit supported, unsupported, and known-difference classifications.
- Add the oracle to pull-request and main-branch CI and to `scripts/test-integration.sh`.

## Compatibility findings fixed

Running the oracle against real services exposed three correctness issues that are fixed here:

- Advertise `standard_conforming_strings=on` so pgx can use the simple query protocol.
- Normalize DuckDB's binary UUID result into canonical Postgres UUID text before pgwire encoding.
- Write Postgres `timestamp` to Parquet with `isAdjustedToUTC=false`, while retaining `true` for `timestamptz`; this prevents local timezone shifts when Iceberg is queried.

Known storage-type differences remain explicitly classified for numeric, unconstrained numeric, varchar, JSONB, and Iceberg smallint mapping.

## Validation

Started fresh Postgres and MinIO containers, built Streambed, synced the fixture separately to Iceberg and DuckLake, started the Streambed query server, and compared every query through pgwire:

```bash
docker compose -f test/integration/docker-compose.yml down -v
docker compose -f test/integration/docker-compose.yml up -d postgres minio --wait
docker compose -f test/integration/docker-compose.yml up createbucket
go test -tags integration -v -count=1 -timeout 10m ./test/querycompat
```

Result: PASS for Iceberg and DuckLake.

Also ran:

```bash
go test ./internal/... ./config/...
go test -race ./internal/server ./internal/parquet
git diff --check
bash -n scripts/test-integration.sh
```
