### PR TITLE
Use DuckDB for the default DuckLake catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,36 @@ Run `streambed sync --help` for all configuration options. All flags support env
 
 Use `--target-file-size-mb` (or `STREAMBED_TARGET_FILE_SIZE_MB`) to split large flushes into approximately target-sized Parquet data files. The default is 128 MiB. This is a target, not a hard maximum; small flushes still create small files.
 
+### DuckLake catalog defaults
+
+With `--target-format=ducklake`, Streambed stores catalog metadata in a local
+DuckDB database by default:
+
+```text
+~/.streambed/ducklake-catalog.duckdb
+```
+
+Parquet data remains under `s3://<bucket>/<prefix>/ducklake/`. Both catalog
+settings can be overridden explicitly:
+
+```bash
+--ducklake-catalog=/path/to/catalog.duckdb \
+--ducklake-catalog-store=duckdb
+```
+
+SQLite catalogs remain supported with `--ducklake-catalog-store=sqlite`.
+Installations created before the DuckDB default must pass both legacy settings
+to continue using their existing catalog; Streambed does not silently migrate
+or overwrite it:
+
+```bash
+--ducklake-catalog="$HOME/.streambed/ducklake-catalog.sqlite" \
+--ducklake-catalog-store=sqlite
+```
+
+The equivalent environment variables are `STREAMBED_DUCKLAKE_CATALOG` and
+`STREAMBED_DUCKLAKE_CATALOG_STORE`.
+
 ## Architecture
 
 ![Architecture](/docs/architecture.svg)

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	StatePath            string
 	TargetFormat         string // lakehouse target: "iceberg" or "ducklake"
 	DuckLakeCatalog      string // catalog DB path for DuckLake metadata
-	DuckLakeCatalogStore string // DuckLake catalog store: "sqlite" (default) or "duckdb"
+	DuckLakeCatalogStore string // DuckLake catalog store: "duckdb" (default) or "sqlite"
 	DuckLakeDataPath     string // DuckLake data path (defaults to s3://bucket/prefix/ducklake/)
 	SlotName             string
 	FlushRows            int
@@ -37,7 +37,7 @@ func Default() *Config {
 		StatePath:            defaultStatePath(),
 		TargetFormat:         "iceberg",
 		DuckLakeCatalog:      defaultDuckLakeCatalogPath(),
-		DuckLakeCatalogStore: "sqlite",
+		DuckLakeCatalogStore: "duckdb",
 		SlotName:             "streambed",
 		FlushRows:            10000,
 		FlushInterval:        2 * time.Second,
@@ -58,9 +58,9 @@ func defaultStatePath() string {
 func defaultDuckLakeCatalogPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ".streambed/ducklake-catalog.sqlite"
+		return ".streambed/ducklake-catalog.duckdb"
 	}
-	return home + "/.streambed/ducklake-catalog.sqlite"
+	return home + "/.streambed/ducklake-catalog.duckdb"
 }
 
 // Load reads configuration from environment variables.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -35,11 +36,16 @@ func TestDefaults(t *testing.T) {
 	if cfg.TargetFormat != "iceberg" {
 		t.Errorf("expected TargetFormat 'iceberg', got %q", cfg.TargetFormat)
 	}
-	if cfg.DuckLakeCatalog == "" {
-		t.Error("expected DuckLakeCatalog default")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("user home directory: %v", err)
 	}
-	if cfg.DuckLakeCatalogStore != "sqlite" {
-		t.Errorf("expected DuckLakeCatalogStore 'sqlite', got %q", cfg.DuckLakeCatalogStore)
+	wantCatalog := filepath.Join(home, ".streambed", "ducklake-catalog.duckdb")
+	if cfg.DuckLakeCatalog != wantCatalog {
+		t.Errorf("expected DuckLakeCatalog %q, got %q", wantCatalog, cfg.DuckLakeCatalog)
+	}
+	if cfg.DuckLakeCatalogStore != "duckdb" {
+		t.Errorf("expected DuckLakeCatalogStore 'duckdb', got %q", cfg.DuckLakeCatalogStore)
 	}
 }
 
@@ -112,6 +118,19 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if got := cfg.EffectiveDuckLakeDataPath(); got != "s3://my-bucket/data/ducklake/" {
 		t.Errorf("expected normalized DuckLake data path, got %q", got)
+	}
+}
+
+func TestLoadExplicitSQLiteCatalogFromEnv(t *testing.T) {
+	t.Setenv("STREAMBED_DUCKLAKE_CATALOG", "/tmp/legacy-ducklake.sqlite")
+	t.Setenv("STREAMBED_DUCKLAKE_CATALOG_STORE", "sqlite")
+
+	cfg := Load()
+	if cfg.DuckLakeCatalog != "/tmp/legacy-ducklake.sqlite" {
+		t.Fatalf("DuckLakeCatalog = %q, want explicit SQLite path", cfg.DuckLakeCatalog)
+	}
+	if cfg.DuckLakeCatalogStore != "sqlite" {
+		t.Fatalf("DuckLakeCatalogStore = %q, want sqlite", cfg.DuckLakeCatalogStore)
 	}
 }
 


### PR DESCRIPTION
Closes #90.

## What changed

- Change the default DuckLake catalog store from `sqlite` to `duckdb`.
- Change the default metadata path to `~/.streambed/ducklake-catalog.duckdb`.
- Preserve explicit SQLite catalog support through CLI flags and environment variables.
- Document the catalog/data split and the upgrade procedure for legacy implicit SQLite catalogs.
- Strengthen config tests to assert the exact default path/store and explicit SQLite environment overrides.

## Upgrade behavior

This is an intentional default change rather than an automatic migration. Existing installations that used the previous implicit SQLite catalog must explicitly configure both legacy values:

```bash
--ducklake-catalog="$HOME/.streambed/ducklake-catalog.sqlite" \
--ducklake-catalog-store=sqlite
```

Streambed does not convert or overwrite the old catalog. Explicit CLI flags and `STREAMBED_DUCKLAKE_CATALOG*` environment variables continue to override defaults.

## Validation

```text
go test ./config/... -count=1
go test ./internal/... ./config/... -count=1
go build -o /tmp/streambed ./cmd/streambed
/tmp/streambed sync --help
```

The generated CLI help reports `.duckdb` and `duckdb` as the defaults.
