### PR TITLE
Fix DuckLake query startup with an empty catalog

### DIFF
--- a/internal/server/ducklake_test.go
+++ b/internal/server/ducklake_test.go
@@ -87,6 +87,58 @@ func TestDuckLakeServerUsesAttachedCatalogDirectly(t *testing.T) {
 	}
 }
 
+func TestDuckLakeServerStartsBeforePublicSchemaExists(t *testing.T) {
+	for _, store := range []string{"duckdb", "sqlite"} {
+		t.Run(store, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			catalogPath := filepath.Join(dir, "catalog."+store)
+			dataPath := filepath.Join(dir, "data") + "/"
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+			writer, err := ducklake.NewWriter(ctx, ducklake.Config{
+				CatalogPath:  catalogPath,
+				CatalogStore: store,
+				DataPath:     dataPath,
+			}, nil, 100, time.Hour, logger)
+			if err != nil {
+				t.Fatalf("ducklake writer: %v", err)
+			}
+			defer writer.Close()
+
+			// The catalog has main at this point, but no PostgreSQL public schema.
+			srv, err := NewServer(ServerConfig{
+				ListenAddr:           ":0",
+				TargetFormat:         "ducklake",
+				DuckLakeCatalog:      catalogPath,
+				DuckLakeCatalogStore: store,
+				DuckLakeDataPath:     dataPath,
+			}, nil, logger)
+			if err != nil {
+				t.Fatalf("NewServer with empty catalog: %v", err)
+			}
+			defer srv.Close()
+
+			var currentSchema string
+			if err := srv.duckDB.QueryRow(`SELECT current_schema()`).Scan(&currentSchema); err != nil {
+				t.Fatalf("current schema: %v", err)
+			}
+			if currentSchema != "main" {
+				t.Fatalf("current schema = %q, want main", currentSchema)
+			}
+
+			writeDuckLakeRow(t, writer, "orders", 1, "alice")
+			if err := writer.FlushAll(ctx); err != nil {
+				t.Fatalf("flush first public table: %v", err)
+			}
+
+			// Resetting the per-query session must notice public and make the new
+			// table available without restarting the server.
+			assertDuckLakeCount(t, srv, `orders`, 1)
+		})
+	}
+}
+
 func TestDuckLakeServerAttachesCatalogInStandaloneMode(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,9 +120,25 @@ func configureDuckLakeQuerySession(db *sql.DB) error {
 	if _, err := db.Exec("USE streambed"); err != nil {
 		return fmt.Errorf("use ducklake catalog: %w", err)
 	}
-	// Match PostgreSQL's usual default schema while retaining DuckLake's main
-	// schema as a fallback. Missing schemas in the search path are allowed.
-	if _, err := db.Exec("SET search_path = 'streambed.public,streambed.main'"); err != nil {
+
+	// A new DuckLake catalog contains main, but public is only created when the
+	// writer first sees a PostgreSQL relation. DuckDB rejects a search path that
+	// names a missing catalog schema, so include public only after it exists.
+	// DuckLake query sessions are recreated before every client query, which
+	// makes public the preferred schema as soon as the writer creates it.
+	var publicExists bool
+	if err := db.QueryRow(`
+		SELECT count(*) > 0
+		FROM information_schema.schemata
+		WHERE catalog_name = 'streambed' AND schema_name = 'public'
+	`).Scan(&publicExists); err != nil {
+		return fmt.Errorf("check ducklake public schema: %w", err)
+	}
+	searchPath := "streambed.main"
+	if publicExists {
+		searchPath = "streambed.public,streambed.main"
+	}
+	if _, err := db.Exec("SET search_path = '" + searchPath + "'"); err != nil {
 		return fmt.Errorf("configure ducklake search path: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Closes #89.

## What changed

- Detect whether the attached DuckLake catalog contains the PostgreSQL `public` schema before setting the query search path.
- Use `streambed.main` while the catalog is empty.
- Prefer `streambed.public` once the writer creates it.
- Keep the existing fresh, read-only attachment per client query, so the new schema becomes visible without restarting Streambed.
- Add regression coverage for both DuckDB-backed and SQLite-backed DuckLake catalogs.

## Why

DuckDB rejects a search path containing a nonexistent catalog schema. A fresh DuckLake catalog has `main`, while Streambed creates `public` only after the first PostgreSQL relation is flushed. The previous unconditional search path made `sync --target-format=ducklake --query-addr=...` fail during startup.

## Validation

```text
go test ./internal/server -count=1
go test ./internal/... ./config/... -count=1
```

Both pass. The regression test starts the query server before `public` exists, flushes the first table through the writer, then verifies an unqualified query resolves it without recreating the server.
