### PR TITLE
docs: update postgres port mapping to match gettting-started page and add psql prerequisite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         -c max_replication_slots=4
         -c max_wal_senders=4
     ports:
-      - "5433:5432"
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -9,6 +9,7 @@ prev: /docs
 
 - Go 1.22+ with CGO enabled (required for go-duckdb and go-sqlite3)
 - Docker (for local Postgres and MinIO)
+- PostgreSQL client CLI (`psql`)
 
 ## Quick Start
 


### PR DESCRIPTION
## What

  • Updated the Postgres port mapping in docker-compose.yml:11-12 from `5433:5432` to `5432:5432`.
  • Added PostgreSQL client CLI (psql) to the Prerequisites list in getting-started.md:8-13.

  ## Why

  1. **Fixes port conflict:** The Getting Started guide, `README.md`, and `CONTRIBUTING.md` instruct users to start Postgres with Docker Compose, point `--source-url` to `localhost:5432`, and launch Streambed's query server on `:5433`. Mapping Postgres to host port 5433 broke this workflow by:
      • Causing connection refused when connecting to `localhost:5432`.
      • Causing bind: address already in use when Streambed tried to bind its query server to :5433.
      • Causing `psql -p 5433` to connect to Postgres instead of the Streambed query server.
  2. **Clarifies prerequisites:** The quickstart walkthrough uses psql in step 4, but psql was omitted from the prerequisites list.

  ## How to test

  1. Start Postgres and MinIO:
   ```
docker compose up -d
```
  2. Run Streambed sync with the query server on :5433 as documented in Getting Started:
   ```
./streambed sync \
      --source-url="postgres://postgres:test@localhost:5432/postgres" \
      --s3-bucket="streambed" \
      --s3-endpoint="http://localhost:9000" \
      --s3-prefix="test" \
      --query-addr=:5433
```

  5. Verify that Streambed connects to Postgres on 5432 and successfully binds the query server on 5433 without port collision errors.